### PR TITLE
refact: <김상현 #69> refact oauth login logic

### DIFF
--- a/src/main/java/com/example/jariBean/config/SecurityConfig.java
+++ b/src/main/java/com/example/jariBean/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig{
 
         http.authorizeRequests()
                 // 유저 회원가입, 유저 로그인 모두 허용
-                .antMatchers("/api/users/join").permitAll()
+                .antMatchers("/join").permitAll()
                 // swagger 모두 허용
                 .antMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
                 // oauth2 모두 허용

--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
@@ -25,10 +25,10 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
-    private static final ThreadLocal<UserLoginReqDto> requestBodyHolder = new ThreadLocal<>();
     private static final ObjectMapper mapper = new ObjectMapper();
     private AuthenticationManager authenticationManager;
     private TokenRepository tokenRepository;
+    private ThreadLocal<UserLoginReqDto> requestBodyHolder = new ThreadLocal<>();
 
 
     public JwtAuthenticationFilter(AuthenticationManager authenticationManager, TokenRepository tokenRepository) {
@@ -49,8 +49,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             // JWT를 쓴다고 하더라도, 컨트롤러에 진입을 하면 시큐리티 권한 체크, 인증 체크의 도움을 받을 수 있게 세션을 만든다.
             // 이 세션의 유효기간은 request ~ response 까지이다.
             Authentication authentication = authenticationManager.authenticate(authenticationToken);
-
-            requestBodyHolder.set(loginReqDto);
 
             return authentication;
         } catch (Exception e) {
@@ -74,8 +72,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         LoginUser loginUser = (LoginUser) authResult.getPrincipal();
 
         // refresh, access token 생성
-        String accessToken = JwtProcess.create(loginUser);
-        String refreshToken = JwtProcess.createRefreshToken(loginUser);
+        String accessToken = JwtProcess.create(loginUser.getUser());
+        String refreshToken = JwtProcess.createRefreshToken(loginUser.getUser());
         String firebaseToken = loginReqDto.getFirebaseToken();
 
 

--- a/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
@@ -3,28 +3,18 @@ package com.example.jariBean.config.jwt;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.config.jwt.jwtdto.JwtDto;
-import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.User;
-import com.example.jariBean.entity.User.UserRole;
 import com.example.jariBean.handler.ex.CustomForbiddenException;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
 
 @Slf4j
 public class JwtProcess {
 
     // create access JWT
-    public static String create(LoginUser loginUser) {
-
-        User user = loginUser.getUser();
+    public static String create(User user) {
 
         String jwt = JWT.create()
                 .withSubject("jariBean")
@@ -37,9 +27,7 @@ public class JwtProcess {
     }
 
     // create refresh JWT
-    public static String createRefreshToken(LoginUser loginUser) {
-
-        User user = loginUser.getUser();
+    public static String createRefreshToken(User user) {
 
         String jwt = JWT.create()
                 .withSubject("jariBean")

--- a/src/main/java/com/example/jariBean/controller/UserController.java
+++ b/src/main/java/com/example/jariBean/controller/UserController.java
@@ -1,24 +1,17 @@
 package com.example.jariBean.controller;
 
+import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.dto.ResponseDto;
-import com.example.jariBean.dto.user.UserReqDto.UserJoinReqDto;
-import com.example.jariBean.dto.user.UserResDto.UserJoinRespDto;
+import com.example.jariBean.dto.user.UserReqDto.UserRegisterReqDto;
+import com.example.jariBean.dto.user.UserResDto.UserInfoRespDto;
 import com.example.jariBean.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,19 +20,19 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "join user", description = "api for join user")
-    @PostMapping("/join")
-    public ResponseEntity join(@RequestBody @Valid UserJoinReqDto joinReqDto, BindingResult bindingResult) {
-        if(bindingResult.hasErrors()){
-            Map<String, String> errorMap = new HashMap<>();
-            bindingResult.getFieldErrors().forEach(error -> {
-                errorMap.put(error.getField(), error.getDefaultMessage());
-            });
-            return new ResponseEntity<>(new ResponseDto<>(-1, "유효성 검사 실패", errorMap), BAD_REQUEST);
-        }
+    @Operation(summary = "find user me", description = "api for find user me")
+    @GetMapping("/me")
+    public ResponseEntity findProfile(@AuthenticationPrincipal LoginUser loginUser) {
+        UserInfoRespDto userInfo = userService.findUserInfo(loginUser.getUser().getId());
+        return new ResponseEntity<>(new ResponseDto<>(1, "회원정보 조회 성공", userInfo), OK);
+    }
 
-        UserJoinRespDto savedUser = userService.save(joinReqDto);
-        return new ResponseEntity<>(new ResponseDto<>(1, "회원가입 성공", savedUser), CREATED);
+    @Operation(summary = "register user", description = "api for register user")
+    @PutMapping("/register")
+    public ResponseEntity register(@RequestBody UserRegisterReqDto userReqDto) {
+        UserInfoRespDto userInfo = userService.register(userReqDto);
+
+        return new ResponseEntity<>(new ResponseDto<>(1, "회원가입 성공", userInfo), OK);
     }
 
 }

--- a/src/main/java/com/example/jariBean/dto/user/UserReqDto.java
+++ b/src/main/java/com/example/jariBean/dto/user/UserReqDto.java
@@ -1,6 +1,8 @@
 package com.example.jariBean.dto.user;
 
 import com.example.jariBean.entity.User;
+import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -61,6 +63,22 @@ public class UserReqDto {
 
         @NotEmpty(message = "필수: firebaseToken")
         private String firebaseToken;
+
+        @Builder
+        public UserLoginReqDto(String userId, String userName, String firebaseToken) {
+            this.userId = userId;
+            this.userName = userName;
+            this.firebaseToken = firebaseToken;
+        }
+    }
+
+    @Data
+    public static class UserRegisterReqDto {
+        @NotEmpty(message = "필수: id")
+        private String id;
+
+        @NotEmpty(message = "필수: nickaname")
+        private String nickname;
     }
 
 }

--- a/src/main/java/com/example/jariBean/dto/user/UserResDto.java
+++ b/src/main/java/com/example/jariBean/dto/user/UserResDto.java
@@ -1,10 +1,9 @@
 package com.example.jariBean.dto.user;
 
 import com.example.jariBean.entity.User;
+import com.example.jariBean.entity.User.UserRole;
 import com.example.jariBean.util.CustomDateUtil;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 public class UserResDto {
     @Getter
@@ -31,6 +30,24 @@ public class UserResDto {
         public UserJoinRespDto(User user) {
             this.id = user.getId();
             this.nickname = user.getNickname();
+        }
+    }
+
+    @Data
+    public static class UserInfoRespDto {
+        private String id;
+        private String nickname;
+        private String imageUrl;
+        private String description;
+        private UserRole role;
+
+        @Builder
+        public UserInfoRespDto(String id, String nickname, String imageUrl, String description, UserRole role) {
+            this.id = id;
+            this.nickname = nickname;
+            this.imageUrl = imageUrl;
+            this.description = description;
+            this.role = role;
         }
     }
 }

--- a/src/main/java/com/example/jariBean/entity/User.java
+++ b/src/main/java/com/example/jariBean/entity/User.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.example.jariBean.entity.User.UserRole.CUSTOMER;
 import static javax.persistence.EnumType.STRING;
 import static javax.persistence.GenerationType.IDENTITY;
 
@@ -72,19 +73,16 @@ public class User {
     @Version //
     private Integer version;
 
+    public void register() {
+        this.role = CUSTOMER;
+    }
+
     // TODO userRole, UserType
 
     @Getter
     @AllArgsConstructor
     public enum UserRole {
-        ADMIN("관리자"), CUSTOMER("고객"), MANAGER("매니저");
-        private String role;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    public enum UserType {
-        NORMAL("기본"), KAKAO("카카오");
+        ADMIN("관리자"), CUSTOMER("고객"), MANAGER("매니저"), UNREGISTERED("미등록");
         private String role;
     }
 
@@ -100,13 +98,14 @@ public class User {
         this.description = null;
     }
 
-    public void updateAlarm(boolean bool) {
-        this.alarm = bool;
+    public void updateAlarm() {
+        this.alarm = !alarm;
     }
 
-    public void updateInfo(String nickname, String imageUrl) {
+    public void updateBySocialInfo(String nickname, String imageUrl, String password) {
         this.nickname = nickname;
         this.imageUrl = imageUrl;
+        this.password = password;
     }
 
     public void updateInfo(String nickname, String imageUrl, String description) {

--- a/src/main/java/com/example/jariBean/oauth/dto/LoginCode.java
+++ b/src/main/java/com/example/jariBean/oauth/dto/LoginCode.java
@@ -1,0 +1,8 @@
+package com.example.jariBean.oauth.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginCode {
+    private String code;
+}

--- a/src/main/java/com/example/jariBean/oauth/dto/LoginResDto.java
+++ b/src/main/java/com/example/jariBean/oauth/dto/LoginResDto.java
@@ -1,0 +1,19 @@
+package com.example.jariBean.oauth.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class LoginResDto {
+
+    @Data
+    public static class LoginSuccessResDto {
+        private String accessToken;
+        private String refreshToken;
+
+        @Builder
+        public LoginSuccessResDto(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
+}

--- a/src/main/java/com/example/jariBean/oauth/service/OAuthService.java
+++ b/src/main/java/com/example/jariBean/oauth/service/OAuthService.java
@@ -1,6 +1,8 @@
 package com.example.jariBean.oauth.service;
 
+import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
+import com.example.jariBean.oauth.dto.LoginResDto.LoginSuccessResDto;
 import com.example.jariBean.oauth.service.OAuthKakaoService.SocialUserInfo;
 import com.example.jariBean.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import static com.example.jariBean.entity.User.UserRole.CUSTOMER;
+import static com.example.jariBean.entity.User.UserRole.UNREGISTERED;
 
 @Service
 @RequiredArgsConstructor
@@ -23,15 +25,29 @@ public abstract class OAuthService {
 
     public abstract SocialUserInfo getUserInfo(String accessToken);
 
-    public User saveOrUpdate(SocialUserInfo socialUserInfo) {
+    public LoginSuccessResDto saveOrUpdate(SocialUserInfo socialUserInfo, String registrationId) {
+
+        // save or create user
         User user = userRepository.findBySocialId(socialUserInfo.getSocialId())
                 .orElse(User.builder()
                         .socialId(socialUserInfo.getSocialId())
                         .password(passwordEncoder.encode(socialUserInfo.getNickname()))
-                        .role(CUSTOMER)
+                        .role(UNREGISTERED)
                         .build());
 
-        user.updateInfo(socialUserInfo.getNickname(), socialUserInfo.getImageUrl());
-        return userRepository.save(user);
+        // update user info
+        user.updateBySocialInfo(socialUserInfo.getNickname(), socialUserInfo.getImageUrl(), passwordEncoder.encode(socialUserInfo.getNickname()));
+
+        // save or update user
+        User savedUser = userRepository.save(user);
+
+        return LoginSuccessResDto.builder()
+                .accessToken(JwtProcess.create(savedUser))
+                .refreshToken(JwtProcess.createRefreshToken(savedUser))
+                .build();
+    }
+
+    public boolean isExistUser(String socialId) {
+        return userRepository.existsBySocialId(socialId);
     }
 }

--- a/src/main/java/com/example/jariBean/repository/user/UserRepository.java
+++ b/src/main/java/com/example/jariBean/repository/user/UserRepository.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 public interface UserRepository extends MongoRepository<User, String>, UserRepositoryTemplate {
 
     Optional<User> findBySocialId(String userPhoneNumber);
-    boolean existsBySocialId(String phoneNumber);
+
+    Optional<User> findByIdAndNickname(String id, String nickname);
+    boolean existsBySocialId(String socialId);
 
 
 }

--- a/src/main/java/com/example/jariBean/service/UserService.java
+++ b/src/main/java/com/example/jariBean/service/UserService.java
@@ -3,6 +3,8 @@ package com.example.jariBean.service;
 import com.example.jariBean.dto.profile.ProfileReqDto;
 import com.example.jariBean.dto.profile.ProfileResDto.ProfileSummaryResDto;
 import com.example.jariBean.dto.user.UserReqDto.UserJoinReqDto;
+import com.example.jariBean.dto.user.UserReqDto.UserRegisterReqDto;
+import com.example.jariBean.dto.user.UserResDto.UserInfoRespDto;
 import com.example.jariBean.dto.user.UserResDto.UserJoinRespDto;
 import com.example.jariBean.entity.User;
 import com.example.jariBean.handler.ex.CustomApiException;
@@ -59,16 +61,36 @@ public class UserService {
     public void updateAlarmStatus(String userId){
         try {
             User user = userRepository.findById(userId).orElseThrow();
-            if (user.isAlarm()) {
-                user.updateAlarm(false);
-            } else {
-                user.updateAlarm(true);
-            }
+            user.updateAlarm();
             userRepository.save(user);
         } catch (Exception e) {
             throw new CustomDBException("유저 DB에 오류가 존재합니다.");
         }
-
     }
 
+    public UserInfoRespDto findUserInfo(String id) {
+        User user = userRepository.findById(id).orElseThrow(() -> new CustomDBException("no user exists for the given id"));
+        return UserInfoRespDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .imageUrl(user.getImageUrl())
+                .description(user.getDescription())
+                .role(user.getRole())
+                .build();
+    }
+
+    public UserInfoRespDto register(UserRegisterReqDto userReqDto) {
+        User user = userRepository.findByIdAndNickname(userReqDto.getId(), userReqDto.getNickname())
+                .orElseThrow(() -> new CustomDBException("no user exists for the given id and nickname"));
+
+        user.register();
+
+        return UserInfoRespDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .imageUrl(user.getImageUrl())
+                .description(user.getDescription())
+                .role(user.getRole())
+                .build();
+    }
 }

--- a/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
@@ -1,0 +1,36 @@
+package com.example.jariBean.oauth.service;
+
+import com.example.jariBean.entity.User;
+import com.example.jariBean.repository.user.UserRepository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class OAuthServiceTest {
+
+    @Autowired UserRepository userRepository;
+
+    @Test
+    public void isExistUserTest() throws Exception {
+
+        OAuthService oAuthService = new OAuthKakaoService(userRepository);
+
+        // 회원가입을 하지 않은 유저
+        boolean isNotLoggedIn = oAuthService.isExistUser("no-social-id");
+        Assertions.assertThat(isNotLoggedIn).isEqualTo(false);
+
+        // 회원가입된 유저
+        User user = User.builder().socialId("social-id").password("password").build();
+        userRepository.save(user);
+
+        boolean isLoggedIn = oAuthService.isExistUser(user.getSocialId());
+        Assertions.assertThat(isLoggedIn).isEqualTo(true);
+
+    }
+
+}


### PR DESCRIPTION
# ✏️ Description
OAuth 로그인 방식을 변경한다.
### 기존 로그인 방식
- Redirect로 전달받은 code를 이용하여 accessToken을 발급받고 accessToken으로 유저 정보를 획득한 후 그 정보를 다시 요청한 유저에게 반환한다.
- 유저가 로그인 정보를 `/login` url로 요청을 보내면 JWT를 발급해준다.

기존의 방식은 유저 정보를  서버에서 획득하고 다시 유저에게 전달하고 다시 유저가 서버에 유저 정보를 전달하는 불필요한 과정을 가지고 있었다.
특히 서버가 유저에게 유저 정보를 전달할 때 유저 정보를 **쿼리 파라미터**로 전달하는 방식을 사용하고 있었다.
이는 노출되면 안되는 정보가 쿼리 파라미터로 그대로 노출되는 상황이 발생한다.
따라서 사용자 인증과 정보 노출을 피할 수 있는 새로운 로그인 인증 방식을 적용하기로 했다.

### 변경된 로그인 방식
#### `POST` : `/login/{registrationId}`
- 유저가 Kakao, Google에서 발급받은 `code`를 requestBody에 담아 서버에 전달한다.
- 서버는 `code`를 이용하여 accessToken을 발급받고 accessToken으로 유저 정보에 접근한다.
- 참조한 유저 정보가 현재 데이터 베이스에 저장되어 있는지 확인한다.
  - 저장되어 있을 경우 새로 취득한 유저 정보를 이용하여 기존 유저의 정보를 갱신한다.
  - 저장되어 있지 않을 경우 취득한 유저 정보로 `User` 객체를 생성하고 데이터베이스 저장한다.
    - 데이터 베이스에 저장할 때 `UserRole`은 `UNREGISTER` 상태로 저장한다.
- 유저 정보 생성 및 갱신이 완료된 이후 유저 정보를 기반으로 JWT를 생성한 후 Response Body에 담아 Client에게 전달한다.

#### `GET` : `/api/users/me`
- 로그인 절차를 완료한 Client는 발급받은 JWT를 이용하여 유저 정보에 대한 요청을 보낸다.
- 요청에 대한 결과로 유저 정보를 받는다.
  - 유저 정보 중 유저의 역할에 대한 정보인 `UserRole`이 `CUSTOMER`인 경우 더 이상의 추가적인 과정을 수행할 필요가 없다.
  - `UserRole`이 `UNREGISTERED`라면 해당 유저는 회원가입을 진행하지 않은 유저로 판단하고 회원가입 로직을 수행한다.

#### `GET` : `/api/users/register`
- 프론트에서 서비스에 필요한 동의 확인 절차를 수행하고 서버로부터 받은 유저의 `id`, `nickname` 정보를 requestBody에 담아 유저 등록 요청을 보낸다.
- 서버에서는 Client로부터 받은 유저의 `id`, `nickname` 정보에 해당하는 객체가 DB에 존재하는지 확인한다.
  - 유저 정보가 존재한다면 `UserRole`이 `CUSTOMER`로 갱신한다.
  - 유저 정보가 존재하지 않는다면 예외처리를 수행한다.

