### PR TITLE
refact: <김상현 #73> hide jwt secret key and code structure restructuring

### DIFF
--- a/src/main/java/com/example/jariBean/config/SecurityConfig.java
+++ b/src/main/java/com/example/jariBean/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.jariBean.config;
 
 import com.example.jariBean.config.jwt.JwtAuthenticationFilter;
 import com.example.jariBean.config.jwt.JwtAuthorizationFilter;
+import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.util.CustomResponseUtil;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 public class SecurityConfig{
 
     private final TokenRepository tokenRepository;
+    private final JwtProcess jwtProcess;
 
     @Bean // IOC 컨테이너에 BCryptPasswordEncoder 객체 등록
     public BCryptPasswordEncoder passwordEncoder() {
@@ -38,7 +40,7 @@ public class SecurityConfig{
             // 필터 생성!
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
             builder.addFilter(new JwtAuthenticationFilter(authenticationManager, tokenRepository));
-            builder.addFilter(new JwtAuthorizationFilter(authenticationManager));
+            builder.addFilter(new JwtAuthorizationFilter(authenticationManager, jwtProcess));
             super.configure(builder);
         }
 

--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
@@ -28,6 +28,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private static final ObjectMapper mapper = new ObjectMapper();
     private AuthenticationManager authenticationManager;
     private TokenRepository tokenRepository;
+    private JwtProcess jwtProcess;
     private ThreadLocal<UserLoginReqDto> requestBodyHolder = new ThreadLocal<>();
 
 
@@ -72,8 +73,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         LoginUser loginUser = (LoginUser) authResult.getPrincipal();
 
         // refresh, access token 생성
-        String accessToken = JwtProcess.create(loginUser.getUser());
-        String refreshToken = JwtProcess.createRefreshToken(loginUser.getUser());
+        String accessToken = jwtProcess.createAccessToken(loginUser.getUser());
+        String refreshToken = jwtProcess.createRefreshToken(loginUser.getUser());
         String firebaseToken = loginReqDto.getFirebaseToken();
 
 

--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
@@ -2,7 +2,6 @@ package com.example.jariBean.config.jwt;
 
 import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.config.jwt.jwtdto.JwtDto;
-import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.User;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,8 +16,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
-    public JwtAuthorizationFilter(AuthenticationManager authenticationManager) {
+
+    private JwtProcess jwtProcess;
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtProcess jwtProcess) {
         super(authenticationManager);
+        this.jwtProcess = jwtProcess;
     }
 
     @Override
@@ -28,7 +30,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
         if(isExist(header)) {
             String jwt = header.replace(JwtVO.TOKEN_PREFIX, ""); // "BEARER " 제거
-            JwtDto jwtDto = JwtProcess.verify(jwt);
+            JwtDto jwtDto = jwtProcess.verify(jwt);
 
             User user = User.builder().id(jwtDto.getId()).role(User.UserRole.valueOf(jwtDto.getUserRole())).build();
             LoginUser loginUser = new LoginUser(user);

--- a/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
@@ -6,44 +6,48 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.example.jariBean.config.jwt.jwtdto.JwtDto;
 import com.example.jariBean.entity.User;
 import com.example.jariBean.handler.ex.CustomForbiddenException;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
-@Slf4j
+@Component
 public class JwtProcess {
 
+    @Value("${JWT_SECRET_KEY}")
+    private String JWT_SECRET_KEY;
+
     // create access JWT
-    public static String create(User user) {
+    public String createAccessToken(User user) {
 
         String jwt = JWT.create()
                 .withSubject("jariBean")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.ACCESS_EXPIRATION_TIME))
                 .withClaim("userId", user.getId())
                 .withClaim("userRole", user.getRole().toString())
-                .sign(Algorithm.HMAC512(JwtVO.SECRET));
+                .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
 
         return JwtVO.TOKEN_PREFIX + jwt;
     }
 
     // create refresh JWT
-    public static String createRefreshToken(User user) {
+    public String createRefreshToken(User user) {
 
         String jwt = JWT.create()
                 .withSubject("jariBean")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.REFRESH_EXPIRATION_TIME))
                 .withClaim("userId", user.getId())
                 .withClaim("userRole", user.getRole().toString())
-                .sign(Algorithm.HMAC512(JwtVO.SECRET));
+                .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
 
         return JwtVO.TOKEN_PREFIX + jwt;
     }
 
 
     // verify JWT (return 되는 LoginUser 객체를 강제로 시큐리티 세션에 직접 주입할 예정)
-    public static JwtDto verify(String jwt) {
+    public JwtDto verify(String jwt) {
 
-        DecodedJWT decodedJwt = JWT.require(Algorithm.HMAC512(JwtVO.SECRET)).build().verify(jwt);
+        DecodedJWT decodedJwt = JWT.require(Algorithm.HMAC512(JWT_SECRET_KEY)).build().verify(jwt);
 
         // 토큰 만료기간 검증
         Date expiresAt = decodedJwt.getExpiresAt();

--- a/src/main/java/com/example/jariBean/config/jwt/JwtVO.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtVO.java
@@ -1,13 +1,18 @@
 package com.example.jariBean.config.jwt;
 
-public interface JwtVO {
-    // TODO SECRET 은 노출되면 안된다.
-    String SECRET = "secretKey"; // HS256 대칭키
-    String TOKEN_PREFIX = "BEARER ";
+import org.springframework.beans.factory.annotation.Value;
 
-    String ACCESS_HEADER = "ACCESS_AUTHORIZATION";
-    String REFRESH_HEADER = "REFRESH_AUTHORIZATION";
+public class JwtVO {
+    public String SECRET; // HS256 대칭키
+    public static String TOKEN_PREFIX = "BEARER ";
 
-    int ACCESS_EXPIRATION_TIME = 1000 * 60 * 60 * 2; // 2시간
-    int REFRESH_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14; // 2주
+    public static String ACCESS_HEADER = "ACCESS_AUTHORIZATION";
+    public static String REFRESH_HEADER = "REFRESH_AUTHORIZATION";
+
+    public static int ACCESS_EXPIRATION_TIME = 1000 * 60 * 60 * 2; // 2시간
+    public static int REFRESH_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14; // 2주
+
+    public JwtVO(@Value("${JWT_SECRET_KEY}") String SECRET) {
+        this.SECRET = SECRET;
+    }
 }

--- a/src/main/java/com/example/jariBean/entity/Token.java
+++ b/src/main/java/com/example/jariBean/entity/Token.java
@@ -1,14 +1,15 @@
 package com.example.jariBean.entity;
 
-import com.example.jariBean.config.jwt.JwtVO;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 
 @Getter
 @Setter
-@RedisHash(value = "Token", timeToLive = JwtVO.REFRESH_EXPIRATION_TIME)
+@RedisHash(value = "Token")
 public class Token {
 
     @Id

--- a/src/main/java/com/example/jariBean/oauth/service/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/oauth/service/OAuthGoogleService.java
@@ -1,5 +1,6 @@
 package com.example.jariBean.oauth.service;
 
+import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.oauth.dto.GoogleOAuthInfo;
 import com.example.jariBean.oauth.dto.GoogleUserInfo;
 import com.example.jariBean.oauth.service.OAuthKakaoService.SocialUserInfo;
@@ -26,8 +27,8 @@ public class OAuthGoogleService extends OAuthService{
 
     private final String REGISTRATION = "google";
 
-    public OAuthGoogleService(UserRepository userRepository) {
-        super(userRepository);
+    public OAuthGoogleService(UserRepository userRepository, JwtProcess jwtProcess) {
+        super(userRepository, jwtProcess);
     }
 
     @Override

--- a/src/main/java/com/example/jariBean/oauth/service/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/oauth/service/OAuthKakaoService.java
@@ -1,6 +1,7 @@
 package com.example.jariBean.oauth.service;
 
 
+import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.oauth.dto.KakaoOAuthInfo;
 import com.example.jariBean.oauth.dto.KakaoUserInfo;
 import com.example.jariBean.repository.user.UserRepository;
@@ -25,8 +26,8 @@ public class OAuthKakaoService extends OAuthService{
 
     private final String REGISTRATION = "kakao";
 
-    public OAuthKakaoService(UserRepository userRepository) {
-        super(userRepository);
+    public OAuthKakaoService(UserRepository userRepository, JwtProcess jwtProcess) {
+        super(userRepository, jwtProcess);
     }
 
     @Override

--- a/src/main/java/com/example/jariBean/oauth/service/OAuthService.java
+++ b/src/main/java/com/example/jariBean/oauth/service/OAuthService.java
@@ -17,6 +17,7 @@ import static com.example.jariBean.entity.User.UserRole.UNREGISTERED;
 public abstract class OAuthService {
 
     private final UserRepository userRepository;
+    private final JwtProcess jwtProcess;
 
     @Autowired
     private BCryptPasswordEncoder passwordEncoder;
@@ -42,8 +43,8 @@ public abstract class OAuthService {
         User savedUser = userRepository.save(user);
 
         return LoginSuccessResDto.builder()
-                .accessToken(JwtProcess.create(savedUser))
-                .refreshToken(JwtProcess.createRefreshToken(savedUser))
+                .accessToken(jwtProcess.createAccessToken(savedUser))
+                .refreshToken(jwtProcess.createRefreshToken(savedUser))
                 .build();
     }
 

--- a/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.jariBean.oauth.service;
 
+import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
 import com.example.jariBean.repository.user.UserRepository;
 
@@ -14,11 +15,12 @@ import org.springframework.test.context.ActiveProfiles;
 class OAuthServiceTest {
 
     @Autowired UserRepository userRepository;
+    @Autowired JwtProcess jwtProcess;
 
     @Test
     public void isExistUserTest() throws Exception {
 
-        OAuthService oAuthService = new OAuthKakaoService(userRepository);
+        OAuthService oAuthService = new OAuthKakaoService(userRepository, jwtProcess);
 
         // 회원가입을 하지 않은 유저
         boolean isNotLoggedIn = oAuthService.isExistUser("no-social-id");


### PR DESCRIPTION
# ✏️ Description

기존 JWT 를 발급할 때 사용한 Secret Key의 값은 `secretKey` 였다.
테스트 단계에서는 상관 없지만 배포 단계에서는 서비스에 발급하는 JWT의 secret key가 노출된다면 문제가 발생할 수 있다.
배포를 앞둔 상황에서 JWT의 secret key를 HMAC512 알고리즘에 맞추어 새로운 secret key의 값을 생성하고 `.env` 파일에서 따로 관리해야 한다.

기존의 `JwtVO` 객체의 구조는 다음과 같았다.
```
public interface JwtVO {
    // TODO SECRET 은 노출되면 안된다.
    String SECRET = "secretKey"; // HS256 대칭키
    String TOKEN_PREFIX = "BEARER ";

    String ACCESS_HEADER = "ACCESS_AUTHORIZATION";
    String REFRESH_HEADER = "REFRESH_AUTHORIZATION";

    int ACCESS_EXPIRATION_TIME = 1000 * 60 * 60 * 2; // 2시간
    int REFRESH_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 14; // 2주
}
```
`SECRET` 값이 repo에 그대로 업로드 된다면 secret key를 악의적인 사용자에 의해 탈취당할 수 있다.
따라서 해당 값을 private으로 관리하기 위해 실제 secret key는 .env 파일에서 보관한다.
프로그램이 시작할 때 `@Value` 어노테이션을 이용하여 .env에 있는 실제 secret key를 주입하는 방식을 적용하였다.
```
@Value("${JWT_SECRET_KEY}")
String SECRET;
```

`JwtVO` 객체를 수정한 이후 `JwtVO` 객체를 의존적으로 사용하는 모든 파일들의 수정이 필요했다.
`JwtVO` → `JwtProcess` →  `OAuthService` 와 같은 의존성을 가지게 되는 구조를 가지고 있었다.
모든 코드를 수정하면서 의존성이 높은 코드 구조를 가지게 되면 조금의 수정이 발생해도 대대적인 코드 수정이 동반될 수 있다는 것을 배우게 되었다.

# 🛠 Features
- 새로운 secret key 생성
- `.env` 파일에 secret key 를 private 하게 관리

# ❗️Warnning
- [ ] secret key가 노출되지 않도록 잘 관리할 것
