### PR TITLE
Refact  : <기성 # 75> test 코드 작성 및 CafeRepositoryImpl 메소드 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.env
+
+### Firebase ###
+src/main/resources/Firebase/jaribean-e3748-firebase-adminsdk-8jhan-a2717cb833.json
+.dockerignore
+.gitignore
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17-jdk
+LABEL maintainer="jariBean"
+EXPOSE 8080
+ARG JAR_FILE_PATH=/build/libs/*.jar
+COPY ${JAR_FILE_PATH} jaribean.jar
+ENTRYPOINT ["java", "-DenvFile=~/springboot/.env" ,"-jar","/jaribean.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 	maven { url 'https://jitpack.io' }
 }
 
+jar { enabled = false}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/example/jariBean/config/elasticsearch/AbstractElasticSearchConfig.java
+++ b/src/main/java/com/example/jariBean/config/elasticsearch/AbstractElasticSearchConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverte
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 
+@Lazy
 @Configuration
 @EnableElasticsearchRepositories
 public abstract class AbstractElasticSearchConfig extends ElasticsearchConfigurationSupport {

--- a/src/main/java/com/example/jariBean/config/elasticsearch/ElasticSearchConfig.java
+++ b/src/main/java/com/example/jariBean/config/elasticsearch/ElasticSearchConfig.java
@@ -1,6 +1,7 @@
 package com.example.jariBean.config.elasticsearch;
 
 import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -14,10 +15,24 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories
 public class ElasticSearchConfig extends AbstractElasticSearchConfig{
 
+    @Value("${spring.elasticsearch.host}")
+    private String host;
+
+    @Value("${elasticsearch.port}")
+    private int port;
+
+    @Value("${elasticsearch.username}")
+    private String username;
+
+    @Value("${elasticsearch.password}")
+    private String password;
+
     @Override
     public RestHighLevelClient elasticsearchClient() {
         ClientConfiguration clientConfiguration = ClientConfiguration.builder()
                 .connectedTo("localhost:9200")
+                .usingSsl()
+                .withBasicAuth(username, password)
                 .build();
         return RestClients.create(clientConfiguration).rest();
     }

--- a/src/main/java/com/example/jariBean/config/firebase/FCMConfig.java
+++ b/src/main/java/com/example/jariBean/config/firebase/FCMConfig.java
@@ -9,8 +9,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Configuration
@@ -18,11 +20,59 @@ public class FCMConfig {
 
     @Value("${FIREBASE_CLASS_PATH}")
     private String FIREBASE_CLASS_PATH;
+
+    @Value("${TYPE}")
+    private String type;
+
+    @Value("${PROJECT_ID}")
+    private String project_id;
+
+    @Value("${PRIVATE_KEY_ID}")
+    private String private_key_id;
+
+    @Value("${PRIVATE_KEY}")
+    private String private_key;
+
+    @Value("${CLIENT_EMAIL}")
+    private String client_email;
+
+    @Value("${CLIENT_ID}")
+    private String client_id;
+
+    @Value("${AUTH_URI}")
+    private String auth_uri;
+
+    @Value("${TOKEN_URI}")
+    private String token_uri;
+
+    @Value("${AUTH_PROVIDER_X509_CERT_URL}")
+    private String auth_provider_x509_cert_url;
+
+    @Value("${CLIENT_X509_CERT_URL}")
+    private String client_x509_cert_url;
+
+    @Value("${UNIVERSE_DOMAIN}")
+    private String universe_domain;
+
+
     @Bean
     FirebaseMessaging firebaseMessaging() throws IOException {
-        ClassPathResource resource = new ClassPathResource(FIREBASE_CLASS_PATH);
+        String jsonKey = "{\n" +
+                "  \"type\": \""+ type +"\",\n" +
+                "  \"project_id\": \""+ project_id +"\",\n" +
+                "  \"private_key_id\": \""+ private_key_id +"\",\n" +
+                "  \"private_key\": \""+ private_key +"\",\n" +
+                "  \"client_email\": \"" + client_email + "\",\n" +
+                "  \"client_id\": \""+client_id+ "\",\n" +
+                "  \"auth_uri\": \""+ auth_uri +"\",\n" +
+                "  \"token_uri\": \""+ token_uri +"\",\n" +
+                "  \"auth_provider_x509_cert_url\": \"" + auth_provider_x509_cert_url +"\",\n" +
+                "  \"client_x509_cert_url\": \""+ client_x509_cert_url +"\",\n" +
+                "  \"universe_domain\": \""+ universe_domain +"\"\n" +
+                "}";
 
-        InputStream refreshToken = resource.getInputStream();
+
+        InputStream refreshToken = new ByteArrayInputStream(jsonKey.getBytes(StandardCharsets.UTF_8));
 
         FirebaseApp firebaseApp = null;
         List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();

--- a/src/main/java/com/example/jariBean/repository/cafe/CafeRepositoryTemplate.java
+++ b/src/main/java/com/example/jariBean/repository/cafe/CafeRepositoryTemplate.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 public interface CafeRepositoryTemplate {
 
+    List<String> findByWordAndCoordinateNear(List<String> searchingWords,GeoJsonPoint point);
+
 
     List<Cafe> findByCoordinateNear(GeoJsonPoint point, Double distance);
 

--- a/src/main/java/com/example/jariBean/service/FCMNotificationService.java
+++ b/src/main/java/com/example/jariBean/service/FCMNotificationService.java
@@ -1,9 +1,6 @@
 package com.example.jariBean.service;
 
 import com.example.jariBean.dto.firebasedto.FCMReqDto;
-import com.example.jariBean.entity.User;
-import com.example.jariBean.repository.TokenRepository;
-import com.example.jariBean.repository.user.UserRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -17,36 +14,36 @@ import java.util.Optional;
 @Service
 public class FCMNotificationService {
     private final FirebaseMessaging firebaseMessaging;
-    private final UserRepository userRepository;
-    private final TokenRepository tokenRepository;
+//    private final UserRepository userRepository;
+//    private final TokenRepository tokenRepository;
 
-    public void sendNotificationByToken(FCMReqDto fcmReqDto) throws FirebaseMessagingException {
-
-        Optional<User> users = userRepository.findById(fcmReqDto.getUserId());
-
-        if (users.isPresent()){
-            for (User user : users.stream().toList()) {
-                String token = tokenRepository.findById(fcmReqDto.getUserId()).get().getFirebaseToken();
-                if (token != null) {
-
-                    Notification notification = Notification.builder()
-                            .setTitle("jariBean")
-                            .setBody("123")
-                            .build();
-
-                    Message sendMessage = Message.builder()
-                            .setToken(token)
-                            .setNotification(notification)
-                            .build();
-
-                    firebaseMessaging.send(sendMessage);
-                }
-
-            }
-
-        }
-
-    }
+//    public void sendNotificationByToken(FCMReqDto fcmReqDto) throws FirebaseMessagingException {
+//
+//        Optional<User> users = userRepository.findById(fcmReqDto.getUserId());
+//
+//        if (users.isPresent()){
+//            for (User user : users.stream().toList()) {
+//                String token = tokenRepository.findById(fcmReqDto.getUserId()).get().getFirebaseToken();
+//                if (token != null) {
+//
+//                    Notification notification = Notification.builder()
+//                            .setTitle("jariBean")
+//                            .setBody("123")
+//                            .build();
+//
+//                    Message sendMessage = Message.builder()
+//                            .setToken(token)
+//                            .setNotification(notification)
+//                            .build();
+//
+//                    firebaseMessaging.send(sendMessage);
+//                }
+//
+//            }
+//
+//        }
+//
+//    }
 
 
     // test 용

--- a/src/main/java/com/example/jariBean/service/SearchService.java
+++ b/src/main/java/com/example/jariBean/service/SearchService.java
@@ -4,7 +4,6 @@ import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.TableClass;
 import com.example.jariBean.handler.ex.CustomNoContentException;
 import com.example.jariBean.repository.cafe.CafeRepository;
-import com.example.jariBean.repository.cafe.elasticcafe.CafeSearchRepository;
 import com.example.jariBean.repository.reserved.ReservedRepository;
 import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
 import kr.co.shineware.nlp.komoran.core.Komoran;
@@ -12,6 +11,7 @@ import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import kr.co.shineware.nlp.komoran.model.Token;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,8 +27,8 @@ import java.util.Set;
 @Lazy
 public class SearchService {
 
-    @Lazy
-    private final CafeSearchRepository cafeSearchRepository;
+//    @Lazy
+//    private final CafeSearchRepository cafeSearchRepository;
 
     private final ReservedRepository reservedRepository;
 
@@ -56,10 +56,10 @@ public class SearchService {
             Set<String> wordSet = new HashSet<>();
 
             List<String> searchingWords = dividedWord(text);
-            List<String> wordFilterdCafes = cafeSearchRepository.findBySearchingWord(searchingWords, latitude, longitude);
-            System.out.println(wordFilterdCafes);
+            GeoJsonPoint point = new GeoJsonPoint(latitude, longitude);
+            // TODO
+            List<String> wordFilterdCafes = cafeRepository.findByWordAndCoordinateNear(searchingWords, point);
             List<String> optionsFilterdCafes = reservedRepository.findCafeByReserved(wordFilterdCafes, startTime, endTime, seating, tableOptionsList);
-            System.out.println(optionsFilterdCafes);
             List<Cafe> cafes = cafeRepository.findByIds(optionsFilterdCafes);
 
             return cafes;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,10 @@ spring:
   data:
     mongodb:
       uri: ${MONGODB_URI}
-    elasticsearch:
-      rest:
-        uris : ${ELASTICSEARCH_URI}
+  elasticsearch:
+    host: ${ELASTICSEARCH_HOST}
+    username: ${ELASTICSEARCH_USERNAME}
+    password: ${ELASTICSEARCH_PASSWORD}
 
   mvc:
     pathmatch:
@@ -12,7 +13,7 @@ spring:
 
   redis:
     port: 6379
-    host: 127.0.0.1
+    host: ${REDIS_URI}
 
 logging:
   level:

--- a/src/test/java/com/example/jariBean/FCM/FCMTests.java
+++ b/src/test/java/com/example/jariBean/FCM/FCMTests.java
@@ -4,7 +4,11 @@ package com.example.jariBean.FCM;
 import com.example.jariBean.service.FCMNotificationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
 
 @SpringBootTest
 public class FCMTests {
@@ -12,11 +16,14 @@ public class FCMTests {
     @Autowired
     FCMNotificationService fcmNotificationService;
 
-
+    @Value("${FIREBASE_CLASS_PATH}")
+    private String FIREBASE_CLASS_PATH;
     @Test
     public void FCMTest() throws Exception{
 
-        fcmNotificationService.sendNotificationByTokentest("eiMZvMU4TvCk4BNeUEHBoz:APA91bH7pZYQBC_aTV0RR4Y2uvrvN1-5_kTrhZWkpzp3G5r03r86JuqRh3fPThKlgVNTQb_kp7_wsnVfQVh9x0XbiZscqSR6XT62CZ28m1SkBsnKmN12rlSHlDnqnS-v-7Z1gFGXxAv3");
+
+
+        fcmNotificationService.sendNotificationByTokentest("eiMZvMU4TvCk4BNeUEHBoz:APA91bG6uf_mg9I70YslVe4E6nOvrP6pvFkZ8BVIF-8YDnfqYM0tLNQYtMG6pVFdaHCBWWwEbsRBZg5GJ4MHp6RBTgufDOrXovJYxz53xGPWTXpLAEbfTtTmTXV7dtKR8PDENqpOPF74");
 
     }
 }

--- a/src/test/java/com/example/jariBean/repository/cafe/CafeRepositoryTest.java
+++ b/src/test/java/com/example/jariBean/repository/cafe/CafeRepositoryTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @SpringBootTest
-@ActiveProfiles("test")
+//@ActiveProfiles("test")
 class CafeRepositoryTest {
 
     @Autowired CafeRepository cafeRepository;
@@ -204,13 +204,17 @@ class CafeRepositoryTest {
 
     @Test
     public void findByCoordinateNearTest() throws Exception {
+        String word = "무인";
+        List<String> words = new ArrayList<>();
+        words.add(word);
+
         GeoJsonPoint coordinate = new GeoJsonPoint(126.9841888305794, 37.53697168039137);
         Double distance = 50D;
 
-        List<Cafe> cafeList = cafeRepository.findByCoordinateNear(coordinate, distance);
+        List<String> cafeList = cafeRepository.findByWordAndCoordinateNear(words,coordinate);
         System.out.println("byCoordinateDistance.getContent().size() = " + cafeList.size());
         cafeList.forEach(cafe -> {
-            System.out.println(cafe.getId());
+            System.out.println(cafe);
         });
     }
 

--- a/src/test/java/com/example/jariBean/service/ReservedServiceTest.java
+++ b/src/test/java/com/example/jariBean/service/ReservedServiceTest.java
@@ -2,6 +2,7 @@ package com.example.jariBean.service;
 
 import com.example.jariBean.dto.reserved.ReserveReqDto;
 import com.example.jariBean.dto.reserved.ReservedResDto;
+import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.Reserved;
 import com.example.jariBean.handler.ex.CustomDBException;
 import com.example.jariBean.repository.cafe.CafeRepository;
@@ -13,9 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 @SpringBootTest
 public class ReservedServiceTest {
@@ -30,6 +34,36 @@ public class ReservedServiceTest {
 
     @Autowired
     ReserveService reserveService;
+
+    @Test
+    public void findByWordAndCoordinateNearTest() throws Exception {
+        String word1 = "무인";
+        String word2 = "인천";
+        List<String> words = new ArrayList<>();
+        words.add(word1);
+        words.add(word2);
+
+        GeoJsonPoint coordinate = new GeoJsonPoint(126.6487782154, 37.4538193246568);
+        Double distance = 50D;
+
+        List<String> cafeList = cafeRepository.findByWordAndCoordinateNear(words,coordinate);
+        System.out.println("byCoordinateDistance.getContent().size() = " + cafeList.size());
+        cafeList.forEach(cafe -> {
+            System.out.println(cafe);
+        });
+    }
+
+    @Test
+    public void findByCoordinateNearTest() throws Exception {
+        GeoJsonPoint coordinate = new GeoJsonPoint(126.6487782154, 37.4538193246568);
+        Double distance = 5000D;
+
+        List<Cafe> cafeList = cafeRepository.findByCoordinateNear(coordinate, distance);
+        System.out.println("byCoordinateDistance.getContent().size() = " + cafeList.size());
+        cafeList.forEach(cafe -> {
+            System.out.println(cafe.getId());
+        });
+    }
 
 
     @Test
@@ -56,6 +90,7 @@ public class ReservedServiceTest {
         }
 
     }
+
 
     @Test
     public void delteMyReservedTest() {


### PR DESCRIPTION
```
@Transactional
    public List<Cafe> findByText(String text, double latitude, double longitude, LocalDateTime startTime, LocalDateTime endTime, Integer seating ,List<TableClass.TableOption> tableOptionsList){
        try {
            List<String> searchingWords = dividedWord(text);
            // start
            GeoJsonPoint point = new GeoJsonPoint(latitude, longitude);
            List<String> wordFilterdCafes = cafeRepository.findByWordAndCoordinateNear(searchingWords, point);
            // end
            List<String> optionsFilterdCafes = reservedRepository.findCafeByReserved(wordFilterdCafes, startTime, endTime, seating, tableOptionsList);
            List<Cafe> cafes = cafeRepository.findByIds(optionsFilterdCafes);
            return cafes;
        } catch (Exception e) {
            throw new CustomNoContentException("해당되는 결과가 없습니다.");
        }
```

service 단의 코드에서 원래 elasticsearch에서 위치 정보와 검색어 검색을 구현하는 것으로 했으나 우선적으로 mongosearch로 구현


```
@Override
    public List<String> findByWordAndCoordinateNear(List<String> searchingWords, GeoJsonPoint point) {
        Criteria geoCriteria = new Criteria("coordinate").near(point).maxDistance(5000D);
        Criteria wordCriteria = new Criteria();
        List<Criteria> orCriterias = new ArrayList<>();

        for (String searchingWord : searchingWords) {
            Criteria regexCriteria = new Criteria("name").regex(".*" + searchingWord + ".*");
            orCriterias.add(regexCriteria);
        }
        wordCriteria.orOperator(orCriterias.toArray(new Criteria[0]));
        geoCriteria.andOperator(wordCriteria);

        Query query = new Query(geoCriteria);

        List<String> cafeIds = new ArrayList<>();
        mongoTemplate.find(query, Cafe.class).forEach(cafe -> cafeIds.add(cafe.getId()));

        return cafeIds;
    }
```

새로운 검색 메소드 findByWordAndCoordinateNear를 cafeRepositoryImpl에서 설정함