### PR TITLE
Oauth2

### DIFF
--- a/src/main/java/com/example/jariBean/config/elasticsearch/ElasticSearchConfig.java
+++ b/src/main/java/com/example/jariBean/config/elasticsearch/ElasticSearchConfig.java
@@ -2,7 +2,6 @@ package com.example.jariBean.config.elasticsearch;
 
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -18,13 +17,13 @@ public class ElasticSearchConfig extends AbstractElasticSearchConfig{
     @Value("${spring.elasticsearch.host}")
     private String host;
 
-    @Value("${elasticsearch.port}")
+    @Value("${spring.elasticsearch.port}")
     private int port;
 
-    @Value("${elasticsearch.username}")
+    @Value("${spring.elasticsearch.username}")
     private String username;
 
-    @Value("${elasticsearch.password}")
+    @Value("${spring.elasticsearch.password}")
     private String password;
 
     @Override

--- a/src/main/java/com/example/jariBean/controller/OAuthController.java
+++ b/src/main/java/com/example/jariBean/controller/OAuthController.java
@@ -1,11 +1,12 @@
-package com.example.jariBean.oauth;
+package com.example.jariBean.controller;
 
 import com.example.jariBean.dto.ResponseDto;
-import com.example.jariBean.oauth.dto.LoginCode;
-import com.example.jariBean.oauth.dto.LoginResDto.LoginSuccessResDto;
-import com.example.jariBean.oauth.service.OAuthKakaoService.SocialUserInfo;
-import com.example.jariBean.oauth.service.OAuthService;
-import com.example.jariBean.oauth.service.OAuthServiceFactory;
+import com.example.jariBean.dto.oauth.LoginCode;
+import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
+import com.example.jariBean.service.oauth.OAuthService;
+import com.example.jariBean.service.oauth.OAuthServiceFactory;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -21,10 +22,10 @@ public class OAuthController {
     private OAuthService oAuthService;
     private final OAuthServiceFactory authServiceFactory;
 
+    @Operation(summary = "return social code", description = "api for return social code")
     @GetMapping("/login/oauth2/code/{registrationId}")
     public String returnCode(@RequestParam("code") String code) {
-//        return "redirect:jaribean://code?code=" + code;
-        return "code";
+        return "redirect:jaribean://code?code=" + code;
     }
 
     @PostMapping("/login/{registrationId}")

--- a/src/main/java/com/example/jariBean/controller/OAuthController.java
+++ b/src/main/java/com/example/jariBean/controller/OAuthController.java
@@ -28,6 +28,7 @@ public class OAuthController {
         return "redirect:jaribean://code?code=" + code;
     }
 
+    @Operation(summary = "social login", description = "api for social login")
     @PostMapping("/login/{registrationId}")
     public ResponseEntity login(@PathVariable("registrationId") String registrationId,
                                         @RequestBody LoginCode loginCode) {

--- a/src/main/java/com/example/jariBean/dto/oauth/GoogleOAuthInfo.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/GoogleOAuthInfo.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.Data;
 import lombok.ToString;

--- a/src/main/java/com/example/jariBean/dto/oauth/GoogleUserInfo.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/GoogleUserInfo.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.Data;
 

--- a/src/main/java/com/example/jariBean/dto/oauth/KakaoOAuthInfo.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/KakaoOAuthInfo.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.Data;
 import lombok.ToString;

--- a/src/main/java/com/example/jariBean/dto/oauth/KakaoUserInfo.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/KakaoUserInfo.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.*;
 

--- a/src/main/java/com/example/jariBean/dto/oauth/LoginCode.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/LoginCode.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.Data;
 

--- a/src/main/java/com/example/jariBean/dto/oauth/LoginResDto.java
+++ b/src/main/java/com/example/jariBean/dto/oauth/LoginResDto.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.dto;
+package com.example.jariBean.dto.oauth;
 
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
@@ -1,9 +1,9 @@
-package com.example.jariBean.oauth.service;
+package com.example.jariBean.service.oauth;
 
 import com.example.jariBean.config.jwt.JwtProcess;
-import com.example.jariBean.oauth.dto.GoogleOAuthInfo;
-import com.example.jariBean.oauth.dto.GoogleUserInfo;
-import com.example.jariBean.oauth.service.OAuthKakaoService.SocialUserInfo;
+import com.example.jariBean.dto.oauth.GoogleOAuthInfo;
+import com.example.jariBean.dto.oauth.GoogleUserInfo;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
 import com.example.jariBean.repository.user.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -1,9 +1,9 @@
-package com.example.jariBean.oauth.service;
+package com.example.jariBean.service.oauth;
 
 
 import com.example.jariBean.config.jwt.JwtProcess;
-import com.example.jariBean.oauth.dto.KakaoOAuthInfo;
-import com.example.jariBean.oauth.dto.KakaoUserInfo;
+import com.example.jariBean.dto.oauth.KakaoOAuthInfo;
+import com.example.jariBean.dto.oauth.KakaoUserInfo;
 import com.example.jariBean.repository.user.UserRepository;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -1,9 +1,9 @@
-package com.example.jariBean.oauth.service;
+package com.example.jariBean.service.oauth;
 
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
-import com.example.jariBean.oauth.dto.LoginResDto.LoginSuccessResDto;
-import com.example.jariBean.oauth.service.OAuthKakaoService.SocialUserInfo;
+import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
 import com.example.jariBean.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthServiceFactory.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthServiceFactory.java
@@ -1,4 +1,4 @@
-package com.example.jariBean.oauth.service;
+package com.example.jariBean.service.oauth;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
       uri: ${MONGODB_URI}
   elasticsearch:
     host: ${ELASTICSEARCH_HOST}
+    port: 9200
     username: ${ELASTICSEARCH_USERNAME}
     password: ${ELASTICSEARCH_PASSWORD}
 

--- a/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
@@ -4,6 +4,8 @@ import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
 import com.example.jariBean.repository.user.UserRepository;
 
+import com.example.jariBean.service.oauth.OAuthKakaoService;
+import com.example.jariBean.service.oauth.OAuthService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
# ✏️ Description
모든 OAuth 기능에 대한 Controller, Service, DTO를 `oauth` 폴더에서 관리 중이었다.
Swagger에 API를 등록하기 위해서는 `controller` 폴더에 Controller가 존재해야 한다.
따라서 `oauth` 폴더에 모듈화된 OAuth 기능들을 각 Layer 별로 다시 분리한다.

# 🛠 Features
- `OAuthController` 를 `controller` 폴더로 이동
- `OAuthService`, `OAuthKakaoService`, `OAuthGoogleService` 를 `service` 폴더로 이동
- OAuth DTO를 `dto` 폴더로 이동

