### PR TITLE
refactor <김상현 #84> remove jwt prefix

### DIFF
--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
@@ -26,23 +26,19 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
 
-        String header = request.getHeader(JwtVO.ACCESS_HEADER);
+        String jwt = request.getHeader(JwtVO.ACCESS_HEADER);
 
-        if(isExist(header)) {
-            String jwt = header.replace(JwtVO.TOKEN_PREFIX, ""); // "BEARER " 제거
+        if(jwt != null) {
             JwtDto jwtDto = jwtProcess.verify(jwt);
 
             User user = User.builder().id(jwtDto.getId()).role(User.UserRole.valueOf(jwtDto.getUserRole())).build();
             LoginUser loginUser = new LoginUser(user);
+
             // 임시 세션 강제 주입 (생명주기 request ~ response)
             Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         }
         chain.doFilter(request, response);
-    }
-
-    private boolean isExist(String header) {
-        return (header != null && header.startsWith(JwtVO.TOKEN_PREFIX));
     }
 }

--- a/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
@@ -27,7 +27,7 @@ public class JwtProcess {
                 .withClaim("userRole", user.getRole().toString())
                 .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
 
-        return JwtVO.TOKEN_PREFIX + jwt;
+        return jwt;
     }
 
     // create refresh JWT
@@ -40,7 +40,7 @@ public class JwtProcess {
                 .withClaim("userRole", user.getRole().toString())
                 .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
 
-        return JwtVO.TOKEN_PREFIX + jwt;
+        return jwt;
     }
 
 

--- a/src/main/java/com/example/jariBean/config/jwt/JwtVO.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtVO.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 
 public class JwtVO {
     public String SECRET; // HS256 대칭키
-    public static String TOKEN_PREFIX = "BEARER ";
 
     public static String ACCESS_HEADER = "ACCESS_AUTHORIZATION";
     public static String REFRESH_HEADER = "REFRESH_AUTHORIZATION";


### PR DESCRIPTION
# ✏️ Description
로그인 이후 토큰을 발급할 때, 해당 토큰이 JWT인 것을 인증하기 위해 prefix로 `BEARER`를 추가했었다.
하지만,  사용하는 토큰이 JWT인 것을 서로 공유하고 있고 굳이 `BEARER`를 추가하여 토큰을 parsing 하는 절차가 늘어나는 것은
불필요한 공수라는 의견에 따라 JWT의 prefix를 제거하기로 결정하였다.

# 🛠 Features
- JWT 발급 및 검증 시 prefix인 `BEARER` 제거
- `JwtAuthorizationFilter.java` 수정
- `JwtProcess.java` 수정
- `JwtVO.java` 수정