### PR TITLE
feat: <김상현 #94> Storing JWT in Redis

### DIFF
--- a/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
@@ -3,8 +3,9 @@ package com.example.jariBean.service.oauth;
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.dto.oauth.GoogleOAuthInfo;
 import com.example.jariBean.dto.oauth.GoogleUserInfo;
-import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
+import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -27,8 +28,8 @@ public class OAuthGoogleService extends OAuthService{
 
     private final String REGISTRATION = "google";
 
-    public OAuthGoogleService(UserRepository userRepository, JwtProcess jwtProcess) {
-        super(userRepository, jwtProcess);
+    public OAuthGoogleService(UserRepository userRepository, JwtProcess jwtProcess, TokenRepository tokenRepository) {
+        super(userRepository, tokenRepository, jwtProcess);
     }
 
     @Override

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -4,6 +4,7 @@ package com.example.jariBean.service.oauth;
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.dto.oauth.KakaoOAuthInfo;
 import com.example.jariBean.dto.oauth.KakaoUserInfo;
+import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,8 +27,8 @@ public class OAuthKakaoService extends OAuthService{
 
     private final String REGISTRATION = "kakao";
 
-    public OAuthKakaoService(UserRepository userRepository, JwtProcess jwtProcess) {
-        super(userRepository, jwtProcess);
+    public OAuthKakaoService(UserRepository userRepository, JwtProcess jwtProcess, TokenRepository tokenRepository) {
+        super(userRepository, tokenRepository, jwtProcess);
     }
 
     @Override

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -45,6 +45,7 @@ public abstract class OAuthService {
         // save or update user
         User savedUser = userRepository.save(user);
 
+        //create JWT
         String accessToken = jwtProcess.createAccessToken(savedUser);
         String refreshToken = jwtProcess.createRefreshToken(savedUser);
 

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -1,10 +1,12 @@
 package com.example.jariBean.service.oauth;
 
 import com.example.jariBean.config.jwt.JwtProcess;
-import com.example.jariBean.entity.User;
 import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
-import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
+import com.example.jariBean.entity.Token;
+import com.example.jariBean.entity.User;
+import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,6 +19,7 @@ import static com.example.jariBean.entity.User.UserRole.UNREGISTERED;
 public abstract class OAuthService {
 
     private final UserRepository userRepository;
+    private final TokenRepository tokenRepository;
     private final JwtProcess jwtProcess;
 
     @Autowired
@@ -41,6 +44,17 @@ public abstract class OAuthService {
 
         // save or update user
         User savedUser = userRepository.save(user);
+
+        String accessToken = jwtProcess.createAccessToken(savedUser);
+        String refreshToken = jwtProcess.createRefreshToken(savedUser);
+
+        // storing jwt in redis
+        Token token = Token.builder()
+                .userId(savedUser.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+        tokenRepository.save(token);
 
         return LoginSuccessResDto.builder()
                 .accessToken(jwtProcess.createAccessToken(savedUser))

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -58,8 +58,8 @@ public abstract class OAuthService {
         tokenRepository.save(token);
 
         return LoginSuccessResDto.builder()
-                .accessToken(jwtProcess.createAccessToken(savedUser))
-                .refreshToken(jwtProcess.createRefreshToken(savedUser))
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
@@ -2,8 +2,8 @@ package com.example.jariBean.oauth.service;
 
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
+import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
-
 import com.example.jariBean.service.oauth.OAuthKakaoService;
 import com.example.jariBean.service.oauth.OAuthService;
 import org.assertj.core.api.Assertions;
@@ -17,12 +17,14 @@ import org.springframework.test.context.ActiveProfiles;
 class OAuthServiceTest {
 
     @Autowired UserRepository userRepository;
+    @Autowired TokenRepository tokenRepository;
     @Autowired JwtProcess jwtProcess;
+
 
     @Test
     public void isExistUserTest() throws Exception {
 
-        OAuthService oAuthService = new OAuthKakaoService(userRepository, jwtProcess);
+        OAuthService oAuthService = new OAuthKakaoService(userRepository, jwtProcess, tokenRepository);
 
         // 회원가입을 하지 않은 유저
         boolean isNotLoggedIn = oAuthService.isExistUser("no-social-id");


### PR DESCRIPTION
# 사용자 OAuth 로그인 중 JWT 발급 및 Redis 저장
- issue #94 기능 개발

### 🛠 개발 내역
- `OAuthService` 의 `saveOrUpdate()` 메소드에서 사용자 정보를 저장 및 갱신한 후 JWT를 발급한다.
- 발급한 JWT를 `TokenRepository`에 해당하는 Redis에 저장한다.
```java
//create JWT
String accessToken = jwtProcess.createAccessToken(savedUser);
String refreshToken = jwtProcess.createRefreshToken(savedUser);

// storing jwt in redis
Token token = Token.builder()
        .userId(savedUser.getId())
        .accessToken(accessToken)
        .refreshToken(refreshToken)
        .build();
tokenRepository.save(token);
```

### ❗️ 의존성 문제
- JWT 및 FCM 토큰을 저장하는 `TokenRepository`는 싱글톤으로 스프링에서 관리중이다.
- `OAuthService`에서 사용자의 토큰을 저장할 때 `TokenRepository`를 사용해야 한다.
- 따라서 `OAuthService`에 `TokenRepository`를 선언하게 되고 싱글톤으로 관리되는 `TokenRepository`를 주입받아야 하므로 의존성이 발생하게 된다.
- 의존성이 발생하면서 관련된 OAuthService Layer에 코드 수정이 발생하였다.
