### PR TITLE
bug: <김상현 #96> exception handling for authentication and DB access

### DIFF
--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -4,6 +4,7 @@ package com.example.jariBean.service.oauth;
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.dto.oauth.KakaoOAuthInfo;
 import com.example.jariBean.dto.oauth.KakaoUserInfo;
+import com.example.jariBean.handler.ex.CustomApiException;
 import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
 import lombok.Getter;
@@ -47,6 +48,9 @@ public class OAuthKakaoService extends OAuthService{
                 .bodyValue(bodyValue)
                 .retrieve()
                 .bodyToMono(KakaoOAuthInfo.class)
+                .doOnError(throwable -> {
+                    throw new CustomApiException("KAKAO Access Token 발급 과정에서 오류가 발생하였습니다.");
+                })
                 .block();
 
         return kakaoOAuthInfo.getAccess_token();
@@ -60,6 +64,9 @@ public class OAuthKakaoService extends OAuthService{
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .retrieve()
                 .bodyToMono(KakaoUserInfo.class)
+                .doOnError(throwable -> {
+                    throw new CustomApiException("KAKAO User information 접근 과정에서 오류가 발생하였습니다.");
+                })
                 .block();
 
         return SocialUserInfo.create(

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -4,6 +4,7 @@ import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
 import com.example.jariBean.entity.Token;
 import com.example.jariBean.entity.User;
+import com.example.jariBean.handler.ex.CustomApiException;
 import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
 import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
@@ -55,7 +56,13 @@ public abstract class OAuthService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
-        tokenRepository.save(token);
+
+        // exception for connect redis
+        try {
+            tokenRepository.save(token);
+        } catch (Exception e) {
+            throw new CustomApiException("JWT를 REDIS에 저장하는 과정에서 오류가 발생했습니다.");
+        }
 
         return LoginSuccessResDto.builder()
                 .accessToken(accessToken)


### PR DESCRIPTION
# ✏️ 발생한 문제
- #90 에서 발생한 문제를 해결하는 과정에서 로그인 과정에서 서버에서 오류가 발생했을 경우 예외 처리가 적용되지 않은 것을 확인했다.
- Kakao와 통신하는 과정에서 오류가 발생할 경우 `CustomApiException`이 수행될 수 있도록 코드를 수정한다.

# 🔥 추가 발생 문제
- Kakao와 통신 이후 `Redis`에 JWT를 저장할 때 `Redis` connection에 문제가 발생할 경우에도 예외처리가 되어있지 않았다.
- `Redis` connection에 대한 예외 처리도 추가하였다.

# 🛠 Features
- Kakao와 통신하는 과정인 `OAuthService`의 `getAccessToken()` 메소드와 `getUserInfo()` 메소드에 예외 처리 코드 작성
- 로그인 과정에서 `Redis` DB connection에 대한 예외 처리 코드 작성