### PR TITLE
[FEAT] Implementing a feature to store the FCM token

### DIFF
--- a/src/main/java/com/example/jariBean/controller/FcmController.java
+++ b/src/main/java/com/example/jariBean/controller/FcmController.java
@@ -1,0 +1,24 @@
+package com.example.jariBean.controller;
+
+import com.example.jariBean.dto.ResponseDto;
+import com.example.jariBean.dto.fcm.FCMReqDto.FCMTokenReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class FcmController {
+
+    @PutMapping("/token")
+    public ResponseEntity storingFCMTokenInRedis(@RequestBody FCMTokenReqDto fcmTokenReqDto) {
+        return new ResponseEntity<>(new ResponseDto<>(1, "정보를 성공적으로 가져왔습니다.", null), OK);
+    }
+
+}

--- a/src/main/java/com/example/jariBean/controller/FcmController.java
+++ b/src/main/java/com/example/jariBean/controller/FcmController.java
@@ -1,9 +1,12 @@
 package com.example.jariBean.controller;
 
+import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.dto.ResponseDto;
 import com.example.jariBean.dto.fcm.FCMReqDto.FCMTokenReqDto;
+import com.example.jariBean.service.FcmService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +19,13 @@ import static org.springframework.http.HttpStatus.OK;
 @RequestMapping("/api/fcm")
 public class FcmController {
 
+    private final FcmService fcmService;
+
     @PutMapping("/token")
-    public ResponseEntity storingFCMTokenInRedis(@RequestBody FCMTokenReqDto fcmTokenReqDto) {
-        return new ResponseEntity<>(new ResponseDto<>(1, "정보를 성공적으로 가져왔습니다.", null), OK);
+    public ResponseEntity storingFCMTokenInRedis(@AuthenticationPrincipal LoginUser loginUser,
+                                                 @RequestBody FCMTokenReqDto fcmTokenReqDto) {
+        fcmService.updateFirebaseToken(loginUser.getUser().getId(), fcmTokenReqDto);
+        return new ResponseEntity<>(new ResponseDto<>(1, "FCM 토큰 정보 갱신에 성공하였습니다.", null), OK);
     }
 
 }

--- a/src/main/java/com/example/jariBean/dto/fcm/FCMReqDto.java
+++ b/src/main/java/com/example/jariBean/dto/fcm/FCMReqDto.java
@@ -1,0 +1,11 @@
+package com.example.jariBean.dto.fcm;
+
+import lombok.Data;
+
+public class FCMReqDto {
+
+    @Data
+    public static class FCMTokenReqDto {
+        private String token;
+    }
+}

--- a/src/main/java/com/example/jariBean/dto/fcm/FCMReqDto.java
+++ b/src/main/java/com/example/jariBean/dto/fcm/FCMReqDto.java
@@ -6,6 +6,6 @@ public class FCMReqDto {
 
     @Data
     public static class FCMTokenReqDto {
-        private String token;
+        private String firebaseToken;
     }
 }

--- a/src/main/java/com/example/jariBean/entity/Token.java
+++ b/src/main/java/com/example/jariBean/entity/Token.java
@@ -18,6 +18,9 @@ public class Token {
     private String refreshToken;
     private String firebaseToken;
 
+    public void updateFcmToken(String firebaseToken) {
+        this.firebaseToken = firebaseToken;
+    }
 
     @Builder
     public Token(String userId, String accessToken, String refreshToken, String firebaseToken) {

--- a/src/main/java/com/example/jariBean/service/FcmService.java
+++ b/src/main/java/com/example/jariBean/service/FcmService.java
@@ -1,0 +1,26 @@
+package com.example.jariBean.service;
+
+import com.example.jariBean.dto.fcm.FCMReqDto.FCMTokenReqDto;
+import com.example.jariBean.entity.Token;
+import com.example.jariBean.handler.ex.CustomApiException;
+import com.example.jariBean.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final TokenRepository tokenRepository;
+
+    public void saveToken(String userId, FCMTokenReqDto fcmTokenReqDto) {
+        // find token by userId
+        Token token = tokenRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException("userId에 해당하는 토큰을 찾을 수 없습니다."));
+
+        // update firebase token
+        token.updateFcmToken(fcmTokenReqDto.getFirebaseToken());
+        tokenRepository.save(token);
+    }
+
+}

--- a/src/main/java/com/example/jariBean/service/FcmService.java
+++ b/src/main/java/com/example/jariBean/service/FcmService.java
@@ -13,7 +13,7 @@ public class FcmService {
 
     private final TokenRepository tokenRepository;
 
-    public void saveToken(String userId, FCMTokenReqDto fcmTokenReqDto) {
+    public void updateFirebaseToken(String userId, FCMTokenReqDto fcmTokenReqDto) {
         // find token by userId
         Token token = tokenRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException("userId에 해당하는 토큰을 찾을 수 없습니다."));


### PR DESCRIPTION
# ✏️ Description
클라이언트에서 로그인 이후 Firebase에서 토큰을 발급한 이후 서버에 전달하여 Redis에 FCM 토큰을 갱신해준다.

# 🛠 Features
- [x] `FcmController` 생성 후 FCM 토큰을 등록할 수 있는 controller를 등록
- [x] 사용자에게 FCM 토큰을 받기 위한 req dto 생성
- [x] FCM 토큰을 갱신하기 위한 `updateFcmToken()` 메소드 구현 
- [x] `FcmService` 생성 후 클라이언트로부터 획득한 FCM 토큰을 Redis에 저장하는 기능 구현
- [x] `FcmService`에서 구현한 기능을 controller에 연동