### PR TITLE
refactor: <김상현 #105> remove request body for user registration

### DIFF
--- a/src/main/java/com/example/jariBean/controller/UserController.java
+++ b/src/main/java/com/example/jariBean/controller/UserController.java
@@ -2,14 +2,16 @@ package com.example.jariBean.controller;
 
 import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.dto.ResponseDto;
-import com.example.jariBean.dto.user.UserReqDto.UserRegisterReqDto;
 import com.example.jariBean.dto.user.UserResDto.UserInfoRespDto;
 import com.example.jariBean.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.http.HttpStatus.OK;
 
@@ -29,8 +31,8 @@ public class UserController {
 
     @Operation(summary = "register user", description = "api for register user")
     @PutMapping("/register")
-    public ResponseEntity register(@RequestBody UserRegisterReqDto userReqDto) {
-        UserInfoRespDto userInfo = userService.register(userReqDto);
+    public ResponseEntity register(@AuthenticationPrincipal LoginUser loginUser) {
+        UserInfoRespDto userInfo = userService.register(loginUser.getUser().getId());
 
         return new ResponseEntity<>(new ResponseDto<>(1, "회원가입 성공", userInfo), OK);
     }

--- a/src/main/java/com/example/jariBean/dto/user/UserReqDto.java
+++ b/src/main/java/com/example/jariBean/dto/user/UserReqDto.java
@@ -2,7 +2,6 @@ package com.example.jariBean.dto.user;
 
 import com.example.jariBean.entity.User;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -70,15 +69,6 @@ public class UserReqDto {
             this.userName = userName;
             this.firebaseToken = firebaseToken;
         }
-    }
-
-    @Data
-    public static class UserRegisterReqDto {
-        @NotEmpty(message = "필수: id")
-        private String id;
-
-        @NotEmpty(message = "필수: nickaname")
-        private String nickname;
     }
 
 }

--- a/src/main/java/com/example/jariBean/repository/user/UserRepository.java
+++ b/src/main/java/com/example/jariBean/repository/user/UserRepository.java
@@ -8,8 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends MongoRepository<User, String>, UserRepositoryTemplate {
 
     Optional<User> findBySocialId(String userPhoneNumber);
-
-    Optional<User> findByIdAndNickname(String id, String nickname);
     boolean existsBySocialId(String socialId);
 
 

--- a/src/main/java/com/example/jariBean/service/UserService.java
+++ b/src/main/java/com/example/jariBean/service/UserService.java
@@ -3,7 +3,6 @@ package com.example.jariBean.service;
 import com.example.jariBean.dto.profile.ProfileReqDto;
 import com.example.jariBean.dto.profile.ProfileResDto.ProfileSummaryResDto;
 import com.example.jariBean.dto.user.UserReqDto.UserJoinReqDto;
-import com.example.jariBean.dto.user.UserReqDto.UserRegisterReqDto;
 import com.example.jariBean.dto.user.UserResDto.UserInfoRespDto;
 import com.example.jariBean.dto.user.UserResDto.UserJoinRespDto;
 import com.example.jariBean.entity.User;
@@ -79,12 +78,15 @@ public class UserService {
                 .build();
     }
 
-    public UserInfoRespDto register(UserRegisterReqDto userReqDto) {
-        User user = userRepository.findByIdAndNickname(userReqDto.getId(), userReqDto.getNickname())
-                .orElseThrow(() -> new CustomDBException("no user exists for the given id and nickname"));
+    public UserInfoRespDto register(String userId) {
+        // find user by id
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomDBException("no user exists for the given id"));
 
+        // update user role
         user.register();
 
+        // return user info
         return UserInfoRespDto.builder()
                 .id(user.getId())
                 .nickname(user.getNickname())


### PR DESCRIPTION
# ✏️ Description
- 소셜 아이디로 로그인을 시도한 사용자 중 회원 정보가 서버에 보관되지 않은 유저 즉, 회원가입되지 않은 사용자는 회원가입 로직을 수행해야 한다.
- 현재 해당 기능은 request body로 `id` 와 `nickname`을 parameter로 요청하고 있다.
### Request Body
```json
{
  "id": "String",
  "nickname": "String"
}
```
- 굳이 request body에 해당 parameter를 전달받지 않아도 요청 헤더의 JWT 검증을 통해 사용자 인증을 수행할 수 있다.
- 따라서 해당 request body 값을 제거하기로 하였다.

# 🛠 수정 내용
- 회원을 등록하기 위해 요청했던 `UserRegisterReqDto` 제거
- 회원을 등록하는 controller의 `@RequestBody` 제거
- `UserService`의 회원을 등록하는 메소드인 `register()`의 파라미터를 `UserRegisterReqDto`에서 `userId`로 변경
- `UserRegisterReqDto`로 회원을 조회하던 로직을 `userId`로 회원을 조회할 수 있도록 `register()` 메소드를 수정