### PR TITLE
bug: <김상현 #103> refactor ExceptionHandler of RestControllerAdvice

### DIFF
--- a/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
@@ -3,11 +3,16 @@ package com.example.jariBean.handler;
 import com.example.jariBean.dto.ResponseDto;
 import com.example.jariBean.handler.ex.*;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.MethodNotSupportedException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.MethodNotAllowedException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.net.ConnectException;
 
 @RestControllerAdvice
 @Slf4j
@@ -56,4 +61,35 @@ public class CustomExceptionHandler {
 
         return new ResponseEntity<>(httpHeaders, HttpStatus.PERMANENT_REDIRECT);
     }
+
+    // handling exceptions for no DB connect
+    @ExceptionHandler(ConnectException.class)
+    public ResponseEntity<?> apiException(ConnectException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "DB 연결에 오류가 발생하였습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // handling exceptions for disallowed methods
+    @ExceptionHandler(MethodNotAllowedException.class)
+    public ResponseEntity<?> apiException(MethodNotAllowedException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "해당 Method는 허용되지 않습니다."), HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+
+    // handling exceptions for not allowed
+    @ExceptionHandler(MethodNotSupportedException.class)
+    public ResponseEntity<?> apiException(MethodNotSupportedException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "URL과 Method가 일치하지 않습니다."), HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    // handling exceptions for not found
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<?> apiException(NoHandlerFoundException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "URL에 해당하는 Controller가 없습니다."), HttpStatus.NOT_FOUND);
+    }
+
+
 }

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -4,7 +4,6 @@ import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
 import com.example.jariBean.entity.Token;
 import com.example.jariBean.entity.User;
-import com.example.jariBean.handler.ex.CustomApiException;
 import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
 import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
@@ -57,12 +56,7 @@ public abstract class OAuthService {
                 .refreshToken(refreshToken)
                 .build();
 
-        // exception for connect redis
-        try {
-            tokenRepository.save(token);
-        } catch (Exception e) {
-            throw new CustomApiException("JWT를 REDIS에 저장하는 과정에서 오류가 발생했습니다.");
-        }
+        tokenRepository.save(token);
 
         return LoginSuccessResDto.builder()
                 .accessToken(accessToken)


### PR DESCRIPTION
# 🔥 문제 인식
스프링 부트에서는 에러 처리를 위한 BasicErrorController를 구현해두었고, 스프링 부트는 예외가 발생하면 기본적으로 `/error`로 에러 요청을 다시 전달하도록 WAS 설정을 해두었다.

기본 설정으로 제공하는 에러 응답은 다음과 같다.
```
{
    "timestamp": "2023-08-20T03:35:44.675+00:00",
    "status": 500,
    "error": "Internal Server Error",
    "path": "/api/users/register"
}
```

해당 응답은 서버에서 오류가 발생했다는 것을 확인할 수 있지만 클라이언트 입장에서는 정확히 서버에서 어떤 오류가 발생했는지 확인하기에는 어려움이 발생할 수 있다.

# 💡 해결 방안
스프링은 **전역적으로 예외를 처리**할 수 있는 `@RestControllerAdvice` 어노테이션을 제공하고 있다.

`@RestControllerAdvice`를 이용함으로써 누릴 수 있는 이점은 다음과 같다.
```
하나의 클래스로 모든 컨트롤러에 대해 전역적으로 예외 처리가 가능함
직접 정의한 에러 응답을 일관성있게 클라이언트에게 내려줄 수 있음
```

현재 코드에 `@RestControllerAdvice`가 작성되어 있지만 전체적인 오류 처리에 적용할 수 있도록 코드를 수정해야 한다.

# 🛠 문제 해결

예외처리를 전역으로 관리해주는 `@RestControllerAdvice` 에 발생할 수 있을 것이라고 예측이 가능한 `@ExceptionHandler` 로 관리한다.

###  ConnectException.class
- DB 연결에 오류가 생길 때 발생하는 Exception
```java
@ExceptionHandler(ConnectException.class)
public ResponseEntity<?> apiException(ConnectException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "DB 연결에 오류가 발생하였습니다."), HttpStatus.BAD_REQUEST);
}
```

### MethodNotAllowedException.class
- API 요청 시 `URL` pattern 과 `Method` 가 허용되지 않는 경우 발생하는 Exception
```java
@ExceptionHandler(MethodNotAllowedException.class)
public ResponseEntity<?> apiException(MethodNotAllowedException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.METHOD_NOT_ALLOWED);
}
```

### MethodNotSupportedException.class
- API 요청 시 `URL` pattern 과 `Method` 가 일치하지 않는 경우 발생하는 Exception
```java
@ExceptionHandler(MethodNotAllowedException.class)
public ResponseEntity<?> apiException(MethodNotAllowedException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.METHOD_NOT_ALLOWED);
}
```

###  NoHandlerFoundException.class
- 요청 URL에 해당하는 pattern이 존재하지 않을 경우 발생하는 Exception
```java
@ExceptionHandler(NoHandlerFoundException.class)
public ResponseEntity<?> apiException(NoHandlerFoundException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "URL에 해당하는 Controller가 없습니다."), HttpStatus.NOT_FOUND);
}
```