### PR TITLE
bug: <김상현 #113> change user role after registration

### DIFF
--- a/src/main/java/com/example/jariBean/service/UserService.java
+++ b/src/main/java/com/example/jariBean/service/UserService.java
@@ -78,6 +78,7 @@ public class UserService {
                 .build();
     }
 
+    @Transactional
     public UserInfoRespDto register(String userId) {
         // find user by id
         User user = userRepository.findById(userId)
@@ -85,6 +86,7 @@ public class UserService {
 
         // update user role
         user.register();
+        userRepository.save(user);
 
         // return user info
         return UserInfoRespDto.builder()


### PR DESCRIPTION
# ✏️ 설명
회원가입 요청을 보낸 후, 회원가입이 성공했음을 확인했음에도 불구하고, 회원정보를 조회하면 가입이 안된 유저라고 나오는 오류.

# 🌌 발생 Controller 
- `users/register` 및 `users/me`

# 🧾 상황 재현
1. 회원가입을 한다.
2. 유저 정보를 조회한다.

# 💻 결과
1. 회원가입
```json
{
    "code": 1,
    "msg": "회원가입 성공",
    "data": {
        "id": "64dc885072a967459a2643c3",
        "nickname": "이호선",
        "imageUrl": "http://k.kakaocdn.net/dn/cw05BO/btrRMKrtXns/nRi7TXEZfN2dWRPLgkk3m0/img_640x640.jpg",
        "description": null,
        "role": "CUSTOMER"
    }
}
```
2. 유저 정보 조회
```json
{
    "code": 1,
    "msg": "회원정보 조회 성공",
    "data": {
        "id": "64dc885072a967459a2643c3",
        "nickname": "이호선",
        "imageUrl": "http://k.kakaocdn.net/dn/cw05BO/btrRMKrtXns/nRi7TXEZfN2dWRPLgkk3m0/img_640x640.jpg",
        "description": null,
        "role": "UNREGISTERED"
    }
}
```
***
# 🔥 Problem
더티 체킹이란 JPA에서는 트랜잭션이 끝나는 시점에 변화가 있는 모든 엔티티 객체를 데이터베이스에 자동으로 반영해주는 것을 말한다.
따라서 굳이 DB에 save() 메소드를 사용하지 않아도 엔티티에 변화가 발생한 경우 트랜잭션이 종료되는 순간 update 쿼리가 자동으로 생성된다.

하지만 우리가 현재 사용하고 있는 것은 엔티티가 아닌 **Document** 라는 것을 망각하고 있었다.

따라서 더티 체킹에 의존하지 않고 직접 save() 메소드를 통해 변화가 발생한 모든 document를 갱신해주어야 한다.

# 💡 Solution
회원의 `Role`을 `UNREGISTER` 에서 `CUSTOMER`로 변경한 이후 해당 document를 save() 메소드를 통해 변경된 값을 갱신시켜주어야 한다.

```java
// update user role
user.register();
userRepository.save(user);
```

### 변경 전
<img width="1157" alt="image" src="https://github.com/SWM-99-degree/jariBean/assets/85926257/f55d8226-076a-4cc6-9cf2-4a3b9efcbd75">

### 변경 후
<img width="1157" alt="image" src="https://github.com/SWM-99-degree/jariBean/assets/85926257/b38724d3-aa3f-4bae-820f-8b3fba697464">
