### PR TITLE
[BUG] 유저 프로필에 소셜로그인 정보 추가

### DIFF
--- a/src/main/java/com/example/jariBean/dto/user/UserResDto.java
+++ b/src/main/java/com/example/jariBean/dto/user/UserResDto.java
@@ -3,7 +3,10 @@ package com.example.jariBean.dto.user;
 import com.example.jariBean.entity.Role;
 import com.example.jariBean.entity.User;
 import com.example.jariBean.util.CustomDateUtil;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 public class UserResDto {
     @Getter
@@ -34,19 +37,22 @@ public class UserResDto {
     }
 
     @Data
+    @JsonInclude(NON_NULL)
     public static class UserInfoRespDto {
         private String id;
         private String nickname;
         private String imageUrl;
         private String description;
+        private String socialId;
         private Role role;
 
         @Builder
-        public UserInfoRespDto(String id, String nickname, String imageUrl, String description, Role role) {
+        public UserInfoRespDto(String id, String nickname, String imageUrl, String description, String socialId, Role role) {
             this.id = id;
             this.nickname = nickname;
             this.imageUrl = imageUrl;
             this.description = description;
+            this.socialId = socialId;
             this.role = role;
         }
     }

--- a/src/main/java/com/example/jariBean/service/UserService.java
+++ b/src/main/java/com/example/jariBean/service/UserService.java
@@ -74,6 +74,7 @@ public class UserService {
                 .nickname(user.getNickname())
                 .imageUrl(user.getImage())
                 .description(user.getDescription())
+                .socialId(extractProvider(user.getSocialId()))
                 .role(user.getRole())
                 .build();
     }
@@ -96,5 +97,21 @@ public class UserService {
                 .description(user.getDescription())
                 .role(user.getRole())
                 .build();
+    }
+
+    public String extractProvider(String socialId) {
+        // socialId의 값이 null인 경우
+        if (socialId == null) {
+            throw new CustomApiException("사용자의 socialID의 값이 존재하지 않습니다.");
+        }
+
+        int underscoreIndex = socialId.indexOf('_');
+
+        // socialId의 형식이 잘못 된 경우
+        if (underscoreIndex == -1 || underscoreIndex >= socialId.length() - 1) {
+            throw new CustomApiException("잘못된 socialId 형식입니다.");
+        }
+
+        return socialId.substring(0, underscoreIndex);
     }
 }

--- a/src/test/java/com/example/jariBean/service/ProfileServiceTest.java
+++ b/src/test/java/com/example/jariBean/service/ProfileServiceTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.example.jariBean.entity.User.UserRole.CUSTOMER;
+import static com.example.jariBean.entity.Role.CUSTOMER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest

--- a/src/test/java/com/example/jariBean/service/UserServiceTest.java
+++ b/src/test/java/com/example/jariBean/service/UserServiceTest.java
@@ -1,0 +1,43 @@
+package com.example.jariBean.service;
+
+import com.example.jariBean.handler.ex.CustomApiException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void testExtractProvider_ValidFormat() {
+        String socialId = "kakao_12345";
+        String provider = userService.extractProvider(socialId);
+        assertEquals("kakao", provider);
+    }
+
+    @Test
+    void testExtractProvider_InvalidFormat() {
+        String socialId = "invalid";
+        CustomApiException exception = assertThrows(CustomApiException.class, () -> {
+            userService.extractProvider(socialId);
+        });
+        assertEquals("잘못된 socialId 형식입니다.", exception.getMessage());
+    }
+
+    @Test
+    void testExtractProvider_NullSocialId() {
+        String socialId = null;
+        CustomApiException exception = assertThrows(CustomApiException.class, () -> {
+            userService.extractProvider(socialId);
+        });
+        assertEquals("사용자의 socialID의 값이 존재하지 않습니다.", exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
# ✏️ Description
서버의 `api/users/me`에 대한 응답에서 `SocialLoginType`이 빠져있음.

# 🗺️  발생 Controller
- `/api/users/me`

# 🧾  상황 재현
상단 컨트롤러에 프로필을 요청한다.

# 💻  결과
다음의 DTO를 받는다. 이때. `SocialLoginType`에 대한 정보는 누락되어있다.
```json
{
    "code": 1,
    "msg": "회원정보 조회 성공",
    "data": {
        "id": "64dc885072a967459a2643c3",
        "nickname": "이호선",
        "imageUrl": "http://k.kakaocdn.net/dn/cw05BO/btrRMKrtXns/nRi7TXEZfN2dWRPLgkk3m0/img_640x640.jpg",
        "description": null,
        "role": "UNREGISTERED"
    }
}
```
***
# 🔥 Problem
- `/api/users/me` URL로 클라이언트가 요청할 경우 소셜 로그인할 때 이용한 Provier를 Response로 전달해야 한다.
- 유저 정보를 제공하는 **04_나의정보 Page**에 로그인할 때 이용한 Provier 정보를 제공하기 때문이다. 

<img src="https://github.com/SWM-99-degree/jariBean/assets/85926257/4ed1e07f-93fb-4444-a2f0-807224a626a9" width="250">

# 🛠 Solution
- 요청에 대한 Response인 `UserInfoRespDto` 에 `socialId` 필드를 추가한다.
- `findUserInfo()` 메소드에서 결과를 return할 때 `socialId` 값을 추가해서 반환한다.

# 결과
![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/a3e115f7-1edd-489b-a1d2-b79286bc2c43)