### PR TITLE
refact : <기성 #122> cafeOperatingTime document -> cafe의 칼럼으로 변경

### DIFF
--- a/src/main/java/com/example/jariBean/dto/cafe/CafeResDto.java
+++ b/src/main/java/com/example/jariBean/dto/cafe/CafeResDto.java
@@ -2,7 +2,6 @@ package com.example.jariBean.dto.cafe;
 
 import com.example.jariBean.dto.reserved.ReservedResDto.TableReserveResDto;
 import com.example.jariBean.entity.Cafe;
-import com.example.jariBean.entity.CafeOperatingTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -38,10 +37,10 @@ public class CafeResDto {
         private String instagram;
         private String image;
 
-        public CafeDetailDto(Cafe cafe, CafeOperatingTime cafeOperatingTime) {
+        public CafeDetailDto(Cafe cafe) {
             this.cafeSummaryDto = new CafeSummaryDto(cafe);
-            this.openingHour = cafeOperatingTime.getOpenTime();
-            this.closingHour = cafeOperatingTime.getCloseTime();
+            this.openingHour = cafe.getStartTime();
+            this.closingHour = cafe.getEndTime();
             this.phoneNumber = cafe.getPhoneNumber();
             this.description = cafe.getDescription();
             this.instagram = cafe.getInstagram();

--- a/src/main/java/com/example/jariBean/entity/Cafe.java
+++ b/src/main/java/com/example/jariBean/entity/Cafe.java
@@ -2,6 +2,7 @@ package com.example.jariBean.entity;
 
 
 import lombok.*;
+import net.bytebuddy.asm.Advice;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
@@ -42,6 +43,14 @@ public class Cafe {
 
     @Column(nullable = false)
     private boolean matching;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+
 
     @CreatedDate
     @Column(updatable = false) // 생성일자(createdDate)에 대한 정보는 생성시에만 할당 가능, 갱신 불가

--- a/src/main/java/com/example/jariBean/repository/cafe/CafeRepositoryTemplate.java
+++ b/src/main/java/com/example/jariBean/repository/cafe/CafeRepositoryTemplate.java
@@ -1,6 +1,5 @@
 package com.example.jariBean.repository.cafe;
 
-import com.example.jariBean.dto.dbconnect.CafeJoinOperatingTimeDto;
 import com.example.jariBean.entity.Cafe;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 

--- a/src/main/java/com/example/jariBean/service/CafeService.java
+++ b/src/main/java/com/example/jariBean/service/CafeService.java
@@ -36,7 +36,6 @@ public class CafeService {
 
     private final ReservedRepository reservedRepository;
 
-    private final CafeOperatingTimeRepository cafeOperatingTimeRepository;
 
 
     public List<CafeSummaryDto> getCafeByMatchingCount(Pageable pageable){
@@ -57,8 +56,7 @@ public class CafeService {
         CafeDetailReserveDto cafeDetailReserveDto = new CafeDetailReserveDto();
         try {
             Cafe cafe = cafeRepository.findById(cafeId).orElseThrow();
-            CafeOperatingTime cafeOperatingTime = cafeOperatingTimeRepository.findById(cafeId).orElseThrow();
-            cafeDetailReserveDto.setCafeDetailDto(new CafeDetailDto(cafe, cafeOperatingTime));
+            cafeDetailReserveDto.setCafeDetailDto(new CafeDetailDto(cafe));
 
             Map<String, List<Reserved>> reservedListByTabldIdWithPagination = new LinkedHashMap<>();
             reservedRepository.findReservedByConditions(cafeId, reserveStartTime, reserveEndTime, peopleNumber, tableOptions).forEach(reserved ->
@@ -113,8 +111,7 @@ public class CafeService {
         LocalDateTime now = LocalDateTime.now();
         try {
             Cafe cafe = cafeRepository.findById(cafeId).orElseThrow();
-            CafeOperatingTime cafeOperatingTime = cafeOperatingTimeRepository.findById(cafeId).orElseThrow();
-            cafeDetailReserveDto.setCafeDetailDto(new CafeDetailDto(cafe, cafeOperatingTime));
+            cafeDetailReserveDto.setCafeDetailDto(new CafeDetailDto(cafe));
 
 
             Map<String, List<Reserved>> reservedListByTabldIdWithPagination = new LinkedHashMap<>();
@@ -141,8 +138,8 @@ public class CafeService {
                 tableReserveResDto.setTableDetailDto(tableDetailDto);
 
                 List<availableTime> times = new ArrayList<>();
-                LocalDateTime startTime = cafeOperatingTime.getOpenTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
-                LocalDateTime endTime = cafeOperatingTime.getCloseTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
+                LocalDateTime startTime = cafe.getStartTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
+                LocalDateTime endTime = cafe.getEndTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
                 for (Reserved reserved : reservedList.getValue()) {
                     if (!startTime.isEqual(reserved.getStartTime())){
                         times.add(new availableTime(startTime, reserved.getStartTime()));


### PR DESCRIPTION
# refact : <기성 #122> cafeOperatingTime document -> cafe의 칼럼으로 변경

```
LocalDateTime startTime = cafeOperatingTime.getOpenTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
                
LocalDateTime endTime = cafeOperatingTime.getCloseTime()..withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
                
```

에서 이렇게 변경

```
LocalDateTime startTime = cafe.getStartTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
                
LocalDateTime endTime = cafe.getEndTime().withDayOfMonth(now.getDayOfMonth()).withMonth(now.getMonthValue()).withYear(now.getYear());
                
```

당일 전체 예약을 가져오는 부분에서 operatingTime을 참조하던 것에서 cafe의 startTime과 endTime을 참조할 수 있도록 했다.