### PR TITLE
[REFACTOR] S3 이미지 업로드 방식 수정

### DIFF
--- a/src/main/java/com/example/jariBean/controller/S3Controller.java
+++ b/src/main/java/com/example/jariBean/controller/S3Controller.java
@@ -1,15 +1,19 @@
 package com.example.jariBean.controller;
 
 import com.example.jariBean.dto.ResponseDto;
+import com.example.jariBean.dto.s3.S3ResDto.S3ImageResDto;
 import com.example.jariBean.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
-import static org.springframework.http.HttpStatus.CREATED;
+import java.io.IOException;
+
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,10 +22,10 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @GetMapping("/upload")
-    public ResponseEntity generatePreSignedUrl(@RequestParam("fileName") String fileName) {
-        String preSignedUrl = s3Service.generatePreSignedUrl(fileName);
-        return new ResponseEntity<>(new ResponseDto<>(1, "S3 pre-signed url 발급에 성공하였습니다.", preSignedUrl), CREATED);
+    @PostMapping("/upload")
+    public ResponseEntity imageUpload(@RequestPart MultipartFile imageFile) throws IOException {
+        S3ImageResDto imageResDto = s3Service.upload(imageFile);
+        return new ResponseEntity<>(new ResponseDto<>(1, "이미지 업로드에 성공하였습니다.", imageResDto), OK);
     }
 
 }

--- a/src/main/java/com/example/jariBean/dto/s3/S3ResDto.java
+++ b/src/main/java/com/example/jariBean/dto/s3/S3ResDto.java
@@ -1,0 +1,14 @@
+package com.example.jariBean.dto.s3;
+
+import lombok.Builder;
+import lombok.Data;
+
+public class S3ResDto {
+
+    @Data
+    @Builder
+    public static class S3ImageResDto {
+        private String imageUrl;
+    }
+
+}

--- a/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
@@ -4,6 +4,7 @@ import com.example.jariBean.dto.ResponseDto;
 import com.example.jariBean.handler.ex.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.MethodNotSupportedException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.MethodNotAllowedException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
 
 @RestControllerAdvice
@@ -89,6 +91,18 @@ public class CustomExceptionHandler {
     public ResponseEntity<?> apiException(NoHandlerFoundException e) {
         log.error(e.getMessage());
         return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "URL에 해당하는 Controller가 없습니다."), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity sizeLimitExceededException(SizeLimitExceededException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "업로드가 가능한 파일의 용량은 최대 10MB입니다."), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(UnsupportedEncodingException.class)
+    public ResponseEntity unsupportedEncodingException(UnsupportedEncodingException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "filename의 URL encode에 문제가 발생하였습니다. "), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
 

--- a/src/main/java/com/example/jariBean/service/S3Service.java
+++ b/src/main/java/com/example/jariBean/service/S3Service.java
@@ -1,34 +1,75 @@
 package com.example.jariBean.service;
 
-import com.amazonaws.HttpMethod;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.example.jariBean.dto.s3.S3ResDto.S3ImageResDto;
+import com.example.jariBean.handler.ex.CustomApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
-import java.util.Date;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class S3Service {
 
-    private final AmazonS3Client amazonS3Client;
+    private final AmazonS3 amazonS3;
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    private static final List<String> ALLOWED_IMAGE_TYPES = Arrays.asList(
+            "image/jpg",
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/heic"
+    );
 
     @Value("${AWS_S3_BUCKET}")
     private String BUCKET_NAME;
 
-    public String generatePreSignedUrl(String file) {
-        GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(BUCKET_NAME, generateObjectKey(file))
-                .withMethod(HttpMethod.PUT)
-                .withExpiration(new Date(new Date().getTime() + (60 * 1000)));
-        return amazonS3Client.generatePresignedUrl(req).toString();
+    @Value("${AWS_CDN_URL}")
+    private String AWS_CDN_URL;
+
+    public S3ImageResDto upload(MultipartFile imageFile) throws IOException {
+        // file exception
+        checkFileValidation(imageFile);
+
+        // generate unique filename
+        String uniqueFilename = generateUniqueFilename(imageFile.getOriginalFilename());
+
+        // create metadata
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(imageFile.getSize());
+        metadata.setContentType(imageFile.getContentType());
+
+        // create object request
+        PutObjectRequest putObjectRequest = new PutObjectRequest(BUCKET_NAME, uniqueFilename, imageFile.getInputStream(), metadata);
+
+        // request object upload
+        amazonS3.putObject(putObjectRequest);
+
+        return S3ImageResDto.builder()
+                .imageUrl(AWS_CDN_URL + uniqueFilename)
+                .build();
     }
 
-    public String generateObjectKey(String file) {
-        String[] fileStructure = file.split("\\.");
-        return fileStructure[0] + "-" + LocalDateTime.now() + "." + fileStructure[1];
+    // TODO UnsupportedEncodingException.class에 해당하는 ExceptionHandler 등록!
+    private String generateUniqueFilename(String fileName) throws UnsupportedEncodingException {
+        return UUID.randomUUID() + URLEncoder.encode(fileName, "UTF-8");
     }
 
+    private void checkFileValidation(MultipartFile imageFile) {
+        // check file type
+        if(imageFile.getContentType() == null || !ALLOWED_IMAGE_TYPES.contains(imageFile.getContentType())) {
+            throw new CustomApiException(imageFile.getContentType() + " 형식의 파일은 업로드할 수 없습니다.");
+        }
+    }
 }

--- a/src/main/resources/application-s3.yml
+++ b/src/main/resources/application-s3.yml
@@ -1,3 +1,9 @@
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 cloud:
   aws:
     credentials:
@@ -9,3 +15,4 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+    cdn: ${AWS_CDN_URL}


### PR DESCRIPTION
# ✏️ Description
기존에 구현항 방식은 pre-signed url을 통해 프론트에서 S3 버킷에 직접 이미지를 업로드하는 방식이었다.
이미지를 서버를 거치지 않고 프론트에서 직접 S3 버킷으로 저장하는 방법은 네트워크 낭비를 줄일 수 있었다.

# 🔥 Problem
그러나 프론트에서 직접 S3에 이미지를 업로드하게 되면 다음과 같은 문제가 발생할 수 있다.
- 사용자가 업로드하는 이미지의 타입을 알 수 없다.
- 사용자가 업로드하는 이미지의 크기를 알 수 없다.

# 💡 Solution
위 문제를 방지하기 위해서는 클라이언트에서 S3에 직접 접근하는 것이 아닌 서버를 통해 이미지를 업로드하는 방법으로 수정해야 한다.
1. 클라이언트에서 서버로 이미지 업로드
2. 클라이언트에서 전송한 이미지 형식과 크기를 확인한 후 규격에 맞으면 이미지를 S3에 저장한다.
3. 만약 클라이언트가 전송한 이미지가 규격에 맞지 않으면 예외처리를 수행한다.

### 1. 저장할 파일 이름의 형식
Amazon S3는 파일 이름의 형식에 제한을 두지 않는다.
하지만 URL 경로나 파일 이름에 유니코드 문자나 특수 문자가 포함될 경우 문제가 발생할 수 있다.
파일 이름을 URL 경로로 사용할 때 인코딩 문제가 발생할 수 있다.

**따라서 Java.util에서 제공하는 `URLEncoder` 를 이용하여 클라이언트로부터 전달 받은 `fileName`을 encode 한다.**

### 2. 파일 이름 중복
S3 bucket에 파일 이름이 `jari-bean.png`에 해당하는 이미지 파일이 존재하고,
파일 이름이 같은 `jari-bean.png` 인 파일을 S3 bucket에 저장할 경우 기존에 존재하던 이미지를 덮어쓴다.
다시 말하면 기존의 `jari-bean.png` 이미지는 사라지게 된다.

**업로드 파일 이름 중복이 발생하여 기존 파일이 삭제되는 것을 방지하기 위해 encode된 `fileName` 앞에 임의적으로 생성한 `uuid`를 붙여준다.**

***
# 🛠 Feature
### `S3Controller.java`
- 클라이언트에게 직접 이미지를 받을 수 있도록 로직 변경
```java
@PostMapping("/upload")
public ResponseEntity imageUpload(@RequestPart MultipartFile imageFile) throws IOException {
    S3ImageResDto imageResDto = s3Service.upload(imageFile);
    return new ResponseEntity<>(new ResponseDto<>(1, "이미지 업로드에 성공하였습니다.", imageResDto), OK);
}
```
***
### `S3Service.java`
- S3 bucket에 저장할 파일 이름을 생성하는 메서드
  - 파일 이름의 중복을 제거하기 위해 파일 이름 상단에 임의로 생성한 `UUID`를 붙여준다.
  - 클라이언트에서 제공한 파일 이름을 `URLEncoder`로 파일이름을 `encode()` 한다.
```java
private String generateUniqueFilename(String fileName) throws UnsupportedEncodingException {
    return UUID.randomUUID() + URLEncoder.encode(fileName, "UTF-8");
}
```
- 클라이언트가 업로드한 파일의 타입을 체크하는 메서드
```java
private void checkFileValidation(MultipartFile imageFile) {
    // check file type
    if(imageFile.getContentType() == null || !ALLOWED_IMAGE_TYPES.contains(imageFile.getContentType())) {
        throw new CustomApiException(imageFile.getContentType() + " 형식의 파일은 업로드할 수 없습니다.");
    }
}
```
- 클라이언트가 업로드한 파일을 S3 bucket에 저장하는 메서드
```java
public S3ImageResDto upload(MultipartFile imageFile) throws IOException {
    // file exception
    checkFileValidation(imageFile);

    // generate unique filename
    String uniqueFilename = generateUniqueFilename(imageFile.getOriginalFilename());

    // create metadata
    ObjectMetadata metadata = new ObjectMetadata();
    metadata.setContentLength(imageFile.getSize());
    metadata.setContentType(imageFile.getContentType());

    // create object request
    PutObjectRequest putObjectRequest = new PutObjectRequest(BUCKET_NAME, uniqueFilename, imageFile.getInputStream(), metadata);

    // request object upload
    amazonS3.putObject(putObjectRequest);

    return S3ImageResDto.builder()
            .imageUrl(AWS_CDN_URL + uniqueFilename)
            .build();
}
```
***
### `CustomExceptionHandler.java`

- 업로드가 가능한 파일의 최대 사이즈(`10MB`)를 초과할 경우 발생할 Exception을 처리하는 Handler
```java
@ExceptionHandler(SizeLimitExceededException.class)
public ResponseEntity sizeLimitExceededException(SizeLimitExceededException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "업로드가 가능한 파일의 용량은 최대 10MB입니다."), HttpStatus.INTERNAL_SERVER_ERROR);
}
```
- `URLEncoeer`의 `encode()` 메서드에서 문제가 발생할 경우 Exception을 처리하는 Handler
```java
@ExceptionHandler(UnsupportedEncodingException.class)
public ResponseEntity unsupportedEncodingException(UnsupportedEncodingException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "filename의 URL encode에 문제가 발생하였습니다. "), HttpStatus.INTERNAL_SERVER_ERROR);
}
```
***
### `application-s3.yml`

- 파일 업로드 사이즈를 10MB로 제한하기 위한 설정
```yml
spring:
  servlet:
    multipart:
      max-file-size: 10MB
      max-request-size: 10MB
```