### PR TITLE
[FEAT] [FEAT] Refresh Token을 이용한 JWT 갱신

### DIFF
--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthorizationFilter.java
@@ -33,6 +33,10 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
 
         String jwt = request.getHeader(JwtVO.ACCESS_HEADER);
 
+        if(jwt == null) {
+            jwt = request.getHeader(JwtVO.REFRESH_HEADER);
+        }
+
         if(jwt != null) {
             JwtDto jwtDto = jwtProcess.verify(jwt);
 

--- a/src/main/java/com/example/jariBean/controller/TokenController.java
+++ b/src/main/java/com/example/jariBean/controller/TokenController.java
@@ -1,0 +1,42 @@
+package com.example.jariBean.controller;
+
+import com.example.jariBean.config.auth.LoginUser;
+import com.example.jariBean.dto.ResponseDto;
+import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
+import com.example.jariBean.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.example.jariBean.config.jwt.JwtVO.REFRESH_HEADER;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @Operation(summary = "renew JWT", description = "api for renew JWT")
+    @ApiResponse(
+            responseCode = "200",
+            description = "JWT 갱신 성공",
+            content = @Content(schema = @Schema(implementation = LoginSuccessResDto.class))
+    )
+    @PatchMapping("/jwt")
+    public ResponseEntity renewJWT(@AuthenticationPrincipal LoginUser loginUser, HttpServletRequest request) {
+        String refreshJWT = request.getHeader(REFRESH_HEADER);
+        LoginSuccessResDto loginSuccessResDto = tokenService.renewJWT(loginUser.getUser().getId(), loginUser.getUser().getRole(), refreshJWT);
+        return new ResponseEntity<>(new ResponseDto<>(1, "JWT 갱신 성공", loginSuccessResDto), OK);
+    }
+}

--- a/src/main/java/com/example/jariBean/entity/Token.java
+++ b/src/main/java/com/example/jariBean/entity/Token.java
@@ -30,4 +30,8 @@ public class Token {
         this.firebaseToken = firebaseToken;
     }
 
+    public void renewJWT(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/example/jariBean/service/TokenService.java
+++ b/src/main/java/com/example/jariBean/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.example.jariBean.service;
+
+import com.example.jariBean.config.jwt.JwtProcess;
+import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
+import com.example.jariBean.entity.Role;
+import com.example.jariBean.entity.Token;
+import com.example.jariBean.handler.ex.CustomApiException;
+import com.example.jariBean.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.example.jariBean.config.jwt.JwtProcess.TokenType.ACCESS;
+import static com.example.jariBean.config.jwt.JwtProcess.TokenType.REFRESH;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+    private final JwtProcess jwtProcess;
+
+    public LoginSuccessResDto renewJWT(String userId, Role role, String refreshJWT) {
+
+        // find token set
+        Token fToken = tokenRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException("userId에 해당하는 Token set이 존재하지 않습니다."));
+
+        // create JWT
+        String accessToken = jwtProcess.createJWT(userId, role.toString(), ACCESS);
+        String refreshToken = jwtProcess.createJWT(userId, role.toString(), REFRESH);
+
+        // renew JWT
+        fToken.renewJWT(accessToken, refreshToken);
+        tokenRepository.save(fToken);
+
+        return LoginSuccessResDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}


### PR DESCRIPTION
# ✏️ Description
서버에서 발급한 Access Token의 유효 기간은 2시간이다.
유효 기간이 지난 Access Token을 이용하여 서버에 요청을 보낼 경우 `"토큰 사용기간이 만료되었습니다."` 에 해당하는 응답을 받는다.
`"토큰 사용기간이 만료되었습니다."` 응답을 받은 클라이언트는 특정 URL로 Refresh Token을 전송하여 새로 발급한 AccessToken을 응답 받는다.

# 🛠 Features
- 기존의 `JwtAuthorizationFilter` 에서 `REFRESH_AUTHORIZATION`에 해당하는 토큰을 Request의 헤더에서 추출하는 로직을 추가
- Refresh Token으로 JWT를 갱신할 Controller 생성
- 요청한 Refresh Token이 존재하는지 확인한 후 새롭게 JWT를 발급하고 DB에 해당 값을 갱신한 후 유저에게 반환하는 Service 로직 생성
