### PR TITLE
refactor <김상현 #153> update manager api and add image filed in TableCl…

### DIFF
--- a/src/main/java/com/example/jariBean/controller/ManagerController.java
+++ b/src/main/java/com/example/jariBean/controller/ManagerController.java
@@ -5,11 +5,11 @@ import com.example.jariBean.dto.manager.ManagerReqDto.ManagerJoinReqDto;
 import com.example.jariBean.dto.manager.ManagerReqDto.ManagerTableClassReqDto;
 import com.example.jariBean.dto.manager.ManagerReqDto.ManagerTableReqDto;
 import com.example.jariBean.dto.manager.ManagerResDto.ManagerLoginResDto;
-import com.example.jariBean.dto.manager.ManagerResDto.ManagerReserveResDto;
-import com.example.jariBean.dto.manager.ManagerResDto.ManagerTableResDto;
+import com.example.jariBean.dto.manager.ManagerResDto.ReserveDto;
+import com.example.jariBean.dto.manager.ManagerResDto.TableClassDto;
+import com.example.jariBean.dto.manager.ManagerResDto.TableDto;
 import com.example.jariBean.service.ManagerService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
@@ -53,29 +54,43 @@ public class ManagerController {
         return new ResponseEntity<>(new ResponseDto<>(1, "매칭 상태 변경 완료", null), OK);
     }
 
-    @Operation(summary = "get reserve list", description = "api for get reserve list")
+    @Operation(summary = "find table-class list", description = "api for find table-class list")
     @ApiResponse(
             responseCode = "200",
-            description = "예약 내역 조회 성공",
-            content = @Content(schema = @Schema(implementation = ManagerReserveResDto.class))
+            description = "테이블 클래스 데이터 조회",
+            content = @Content(schema = @Schema(implementation = TableClassDto.class))
     )
-    @GetMapping("/reserve/{cafeId}")
-    public ResponseEntity reservePage(@PathVariable("cafeId") String cafeId) {
-        ManagerReserveResDto reserveResDto = managerService.getReservePage(cafeId);
-        return new ResponseEntity<>(new ResponseDto<>(1, "예약 page 결과", reserveResDto), OK);
+    @GetMapping("/table-class/{cafeId}")
+    public ResponseEntity findTableClass(@PathVariable("cafeId") String cafeId) {
+        List<TableClassDto> tableClassList = managerService.getTableClassList(cafeId);
+        return new ResponseEntity<>(new ResponseDto<>(1, "테이블 클래스 정보 조회 성공", tableClassList), OK);
     }
 
     @Operation(summary = "find table list", description = "api for find table list")
     @ApiResponse(
             responseCode = "200",
-            description = "테이블 내역 조회 성공",
-            content = @Content(array = @ArraySchema(schema = @Schema(implementation = ManagerTableResDto.class)))
+            description = "테이블 데이터 조회",
+            content = @Content(schema = @Schema(implementation = TableDto.class))
     )
-    @GetMapping("/table{cafeId}")
-    public ResponseEntity tablePage(@PathVariable("cafeId") String cafeId) {
-        List<ManagerTableResDto> tablePage = managerService.getTablePage(cafeId);
-        return new ResponseEntity<>(new ResponseDto<>(1, "좌석 page 결과", tablePage), OK);
+    @GetMapping("/table/{tableClassId}")
+    public ResponseEntity findTable(@PathVariable("tableClassId") String tableClassId) {
+        List<TableDto> tableList = managerService.getTableList(tableClassId);
+        return new ResponseEntity<>(new ResponseDto<>(1, "테이블 정보 조회 성공", tableList), OK);
     }
+
+    @Operation(summary = "find reserve list", description = "api for find reserve list")
+    @ApiResponse(
+            responseCode = "200",
+            description = "예약 내역 조회",
+            content = @Content(schema = @Schema(implementation = ReserveDto.class))
+    )
+    @GetMapping("/reserve/{tableClassId}")
+    public ResponseEntity findReserveList(@PathVariable("tableClassId") String tableClassId) {
+        Map<String, List<ReserveDto>> reserveList = managerService.getReserveList(tableClassId);
+        return new ResponseEntity<>(new ResponseDto<>(1, "예약 내역 조회 성공", reserveList), OK);
+    }
+
+
 
     @Operation(summary = "update table information", description = "api for update table information")
     @ApiResponse(

--- a/src/main/java/com/example/jariBean/dto/manager/ManagerResDto.java
+++ b/src/main/java/com/example/jariBean/dto/manager/ManagerResDto.java
@@ -21,8 +21,7 @@ public class ManagerResDto {
         private List<TableReserveDto> tableReserveDtoList = new ArrayList<>();
 
         public void addTableClassSummaryDto(TableClass tableClass) {
-            TableClassSummaryDto tableClassSummaryDto = new TableClassSummaryDto();
-            tableClassSummaryDto.setTableClass(tableClass);
+            TableClassSummaryDto tableClassSummaryDto = new TableClassSummaryDto(tableClass);
             tableClassSummaryDtoList.add(tableClassSummaryDto);
         }
 
@@ -60,17 +59,20 @@ public class ManagerResDto {
 
 
     @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL) // Null 값인 필드 제외
     public static class TableClassSummaryDto {
         private String id;
         private String name;
         private Integer seating;
+        private String image;
         private List<TableOption> option;
         private List<TableSummaryDto> tableSummaryDtoList;
 
-        public void setTableClass(TableClass tableClass) {
+        public TableClassSummaryDto(TableClass tableClass) {
             this.id = tableClass.getId();
             this.name = tableClass.getName();
             this.seating = tableClass.getSeating();
+            this.image = tableClass.getImage();
             this.option = tableClass.getTableOptionList();
         }
     }
@@ -125,6 +127,58 @@ public class ManagerResDto {
             this.id = id;
             this.email = email;
             this.role = role;
+        }
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL) // Null 값인 필드 제외
+    public static class TableClassDto {
+        private String id;
+        private String name;
+        private String image;
+        private int seating;
+        private List<TableOption> tableOptionList;
+
+        public TableClassDto(TableClass tableClass) {
+            this.id = tableClass.getId();
+            this.name = tableClass.getName();
+            this.image = tableClass.getImage();
+            this.seating = tableClass.getSeating();
+            this.tableOptionList = tableClass.getTableOptionList();
+        }
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL) // Null 값인 필드 제외
+    public static class TableDto {
+        private String id;
+        private String name;
+        private String image;
+        private String description;
+
+        public TableDto(Table table) {
+            this.id = table.getId();
+            this.name = table.getName();
+            this.image = table.getImage();
+            this.description = table.getDescription();
+        }
+    }
+
+    @Data
+    @JsonInclude(JsonInclude.Include.NON_NULL) // Null 값인 필드 제외
+    public static class ReserveDto {
+        private String id;
+        private String userId;
+        private String tableId;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+
+        public ReserveDto(Reserved reserved) {
+            this.id = reserved.getId();
+            this.userId = reserved.getUserId();
+            this.tableId = reserved.getTable().getId();
+            this.startTime = reserved.getStartTime();
+            this.endTime = reserved.getEndTime();
         }
     }
 

--- a/src/main/java/com/example/jariBean/entity/TableClass.java
+++ b/src/main/java/com/example/jariBean/entity/TableClass.java
@@ -35,6 +35,8 @@ public class TableClass {
     @Column(nullable = false)
     private List<TableOption> tableOptionList;
 
+    private String image;
+
     @DBRef
     private Cafe cafe;
 

--- a/src/main/java/com/example/jariBean/repository/reserved/ReservedRepository.java
+++ b/src/main/java/com/example/jariBean/repository/reserved/ReservedRepository.java
@@ -17,4 +17,6 @@ public interface ReservedRepository extends MongoRepository<Reserved, String>, R
     Page<Reserved> findByUserIdOrderByStartTimeAsc(String userId, Pageable pageable);
 
     List<Reserved> findByTableIdIn(List<String> tableIdList);
+
+    List<Reserved> findByTableClassId(String tableClassId);
 }

--- a/src/test/java/com/example/jariBean/service/ManagerServiceTest.java
+++ b/src/test/java/com/example/jariBean/service/ManagerServiceTest.java
@@ -1,7 +1,5 @@
 package com.example.jariBean.service;
 
-import com.example.jariBean.dto.manager.ManagerResDto.ManagerReserveResDto;
-import com.example.jariBean.dto.manager.ManagerResDto.ManagerTableResDto;
 import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.Reserved;
 import com.example.jariBean.entity.Table;
@@ -15,7 +13,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -108,55 +105,6 @@ class ManagerServiceTest {
     }
 
     @Test
-    public void getTablePageTest() throws Exception {
-        // given
-        String cafeId = globalCafe.getId();
-
-        // when
-        List<ManagerTableResDto> tablePage = managerService.getTablePage(cafeId);
-
-        // then
-        tablePage.forEach(managerTableResDto -> {
-            System.out.println("managerTableResDto.getName() = " + managerTableResDto.getName());
-            managerTableResDto.getTableSummaryDtoList().forEach(tableSummaryDto -> {
-                System.out.println("tableSummaryDto.getName() = " + tableSummaryDto.getName());
-            });
-        });
-
-        Assertions.assertThat(tablePage.size()).isEqualTo(3);
-        for (ManagerTableResDto managerTableResDto : tablePage) {
-            Assertions.assertThat(managerTableResDto.getTableSummaryDtoList().size()).isEqualTo(3);
-        }
-    }
-
-    @Test
-    public void getReservePageTest() throws Exception {
-        // given
-        String cafeId = globalCafe.getId();
-
-        // when
-        ManagerReserveResDto managerReserveResDto = managerService.getReservePage(cafeId);
-
-        // then
-        managerReserveResDto.getTableClassSummaryDtoList().forEach(tableClassSummaryDto -> {
-            System.out.println("tableClassSummaryDto.getName() = " + tableClassSummaryDto.getName());
-        });
-
-        managerReserveResDto.getTableReserveDtoList().forEach(tableReserveDto -> {
-            System.out.println("tableReserveDto.getTableName() = " + tableReserveDto.getTableName());
-            tableReserveDto.getReservePeriodDtoList().forEach(reservePeriodDto -> {
-                System.out.println("reservePeriodDto.getUsername() = " + reservePeriodDto.getUsername());
-                System.out.println("reservePeriodDto.getStartTime() = " + reservePeriodDto.getStartTime());
-                System.out.println("reservePeriodDto.getEndTime() = " + reservePeriodDto.getEndTime());
-            });
-        });
-
-        Assertions.assertThat(managerReserveResDto.getTableClassSummaryDtoList().size()).isEqualTo(3);
-        Assertions.assertThat(managerReserveResDto.getTableReserveDtoList().size()).isEqualTo(9);
-
-    }
-
-    @Test
     public void updateTableTest() throws Exception {
         // given
         Table table = Table.builder().build();
@@ -237,5 +185,4 @@ class ManagerServiceTest {
         Assertions.assertThat(savedTableClass.getTableOptionList()).isEqualTo(option);
 
     }
-
 }


### PR DESCRIPTION
# ✏️ Description
점주앱에서 카페 테이블에 대한 예약 내역을 조회할 때의 페이지 구성은 다음과 같다.

![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/92a4e23f-1fcd-4f67-bcd9-e40be25242f8)

[테이블 종류] 에서 테이블 클래스에 대한 정보를 제공하는 카드를 보면 테이블 클래스의 이미지가 들어가는 UI를 확인할 수 있다.

![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/a918454a-24c9-4cee-8309-2cf3b36eb597)

현재 `TableClass` document에는 이미지 정보에 대한 필드가 존재하지 않는다.
따라서 `TableClass` document에 `image` 필드를 추가하고 해당 정보를 조회할 수 있도록 Manager API를 수정한다.

Description content

# 🛠 Features
- [x] `TableClass` document에 `image` 필드를 추가
- [x] API의 response에 image가 추가될 수 있도록 API 수정
  - `cafeId`로 `Table Class` 조회하는 API
  - `tableClassId`로 `Table` 조회하는 API
  - `tableClassId`로 `Reserve` 조회하는 API
