### PR TITLE
refactor <김상현 #156> update JWT payload

### DIFF
--- a/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtAuthenticationFilter.java
@@ -82,11 +82,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = jwtProcess.createJWT(
                 loginCafe.getCafeManager().getCafeId(),
                 loginCafe.getCafeManager().getRole().toString(),
+                loginCafe.getCafeManager().getEmail(),
                 JwtProcess.TokenType.ACCESS);
 
         String refreshToken = jwtProcess.createJWT(
                 loginCafe.getCafeManager().getCafeId(),
                 loginCafe.getCafeManager().getRole().toString(),
+                loginCafe.getCafeManager().getEmail(),
                 JwtProcess.TokenType.REFRESH);
 
         // `Token` 생성

--- a/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/jariBean/config/jwt/JwtProcess.java
@@ -18,13 +18,14 @@ public class JwtProcess {
     @Value("${JWT_SECRET_KEY}")
     private String JWT_SECRET_KEY;
 
-    public String createJWT(String id, String userRole, TokenType type) {
+    public String createJWT(String id, String userRole, String username, TokenType type) {
         String jwt = JWT.create()
-               .withSubject("jariBean")
-               .withExpiresAt(new Date(System.currentTimeMillis() + type.getTime()))
-               .withClaim("userId", id)
-               .withClaim("userRole", userRole)
-               .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
+                .withSubject("jariBean")
+                .withExpiresAt(new Date(System.currentTimeMillis() + type.getTime()))
+                .withClaim("userId", id)
+                .withClaim("userRole", userRole)
+                .withClaim("username", username)
+                .sign(Algorithm.HMAC512(JWT_SECRET_KEY));
 
         return jwt;
     }

--- a/src/main/java/com/example/jariBean/controller/TokenController.java
+++ b/src/main/java/com/example/jariBean/controller/TokenController.java
@@ -36,7 +36,7 @@ public class TokenController {
     @PatchMapping("/jwt")
     public ResponseEntity renewJWT(@AuthenticationPrincipal LoginUser loginUser, HttpServletRequest request) {
         String refreshJWT = request.getHeader(REFRESH_HEADER);
-        LoginSuccessResDto loginSuccessResDto = tokenService.renewJWT(loginUser.getUser().getId(), loginUser.getUser().getRole(), refreshJWT);
+        LoginSuccessResDto loginSuccessResDto = tokenService.renewJWT(loginUser.getUser().getId(), loginUser.getUser().getRole(), loginUser.getUser().getNickname(), refreshJWT);
         return new ResponseEntity<>(new ResponseDto<>(1, "JWT 갱신 성공", loginSuccessResDto), OK);
     }
 }

--- a/src/main/java/com/example/jariBean/service/TokenService.java
+++ b/src/main/java/com/example/jariBean/service/TokenService.java
@@ -19,15 +19,15 @@ public class TokenService {
     private final TokenRepository tokenRepository;
     private final JwtProcess jwtProcess;
 
-    public LoginSuccessResDto renewJWT(String userId, Role role, String refreshJWT) {
+    public LoginSuccessResDto renewJWT(String userId, Role role, String nickname, String refreshJWT) {
 
         // find token set
         Token fToken = tokenRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException("userId에 해당하는 Token set이 존재하지 않습니다."));
 
         // create JWT
-        String accessToken = jwtProcess.createJWT(userId, role.toString(), ACCESS);
-        String refreshToken = jwtProcess.createJWT(userId, role.toString(), REFRESH);
+        String accessToken = jwtProcess.createJWT(userId, role.toString(), nickname, ACCESS);
+        String refreshToken = jwtProcess.createJWT(userId, role.toString(), nickname, REFRESH);
 
         // renew JWT
         fToken.renewJWT(accessToken, refreshToken);

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -48,8 +48,8 @@ public abstract class OAuthService {
         User savedUser = userRepository.save(user);
 
         //create JWT
-        String accessToken = jwtProcess.createJWT(savedUser.getId(), savedUser.getRole().toString(), ACCESS);
-        String refreshToken = jwtProcess.createJWT(savedUser.getId(), savedUser.getRole().toString(), REFRESH);
+        String accessToken = jwtProcess.createJWT(savedUser.getId(), savedUser.getRole().toString(), savedUser.getNickname(), ACCESS);
+        String refreshToken = jwtProcess.createJWT(savedUser.getId(), savedUser.getRole().toString(), savedUser.getNickname(), REFRESH);
 
         // storing jwt in redis
         Token token = Token.builder()


### PR DESCRIPTION
# ✏️ Description
현재 JWT payload의 구성은 다음과 같다.
```
{
  "sub": "jariBean",
  "exp": 1694428228,
  "userRole": "MANAGER",
  "userId": "64fd48821a11b172e165f2fd"
}
```
토큰을 발급한 주체, 만료 기간, 사용자 권한, 사용자 id에 대한 정보가 담겨있다.
JWT의 경우 `base64url`로 인코딩 되어 있기 때문에 누구라도 JWT를 디코딩하여 payload의 정보를 확인할 수 있기 때문에 개인 정보가 담긴 내용을 담지 않는 것이 좋다.

하지만, 한번의 매칭 요청을 할 때마다 payload의 `userId`를 이용하여 유저 정보에 접근하는 것은 매우 비효율적이기 때문에 JWT 발급시 payload에 `username` 정보를 추가하기로 결정하였다.

# 🛠 Features
- [x] JWT payload에 `username` 정보 추가하기
