### PR TITLE
bug <김상현 #166> Google 소셜 로그인시 nickname 필드가 존재하지 않을 경우의 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	implementation 'org.apache.poi:poi-ooxml:5.0.0'
 
 	// embedded mongodb
-//	testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
+	testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
 
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/example/jariBean/controller/OAuthController.java
+++ b/src/main/java/com/example/jariBean/controller/OAuthController.java
@@ -49,7 +49,7 @@ public class OAuthController {
         // get user information using accessToken
         SocialUserInfo socialUserInfo = oAuthService.getUserInfo(accessToken);
         // save or update oauth information
-        LoginSuccessResDto loginSuccessResDto = oAuthService.saveOrUpdate(socialUserInfo, registrationId);
+        LoginSuccessResDto loginSuccessResDto = oAuthService.saveOrUpdate(socialUserInfo);
         return new ResponseEntity<>(new ResponseDto<>(1, "로그인 성공", loginSuccessResDto), OK);
     }
 

--- a/src/main/java/com/example/jariBean/repository/user/UserRepository.java
+++ b/src/main/java/com/example/jariBean/repository/user/UserRepository.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends MongoRepository<User, String>, UserRepositoryTemplate {
 
-    Optional<User> findBySocialId(String userPhoneNumber);
+    Optional<User> findBySocialId(String socialId);
     boolean existsBySocialId(String socialId);
 
 

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
@@ -65,7 +65,7 @@ public class OAuthGoogleService extends OAuthService{
         return SocialUserInfo.create(
                 REGISTRATION,
                 userInfo.getId(),
-                userInfo.getName(),
+                userInfo.getName() != null ? userInfo.getName() : "Guest",
                 userInfo.getPicture()
         );
     }

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -76,7 +76,7 @@ public class OAuthKakaoService extends OAuthService{
         return SocialUserInfo.create(
                 REGISTRATION,
                 userInfo.getId(),
-                userInfo.getProperties().getNickname(),
+                userInfo.getProperties().getNickname() != null ? userInfo.getProperties().getNickname() : "Guest",
                 userInfo.getProperties().getProfile_image()
         );
     }

--- a/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
+++ b/src/test/java/com/example/jariBean/oauth/service/OAuthServiceTest.java
@@ -2,15 +2,19 @@ package com.example.jariBean.oauth.service;
 
 import com.example.jariBean.config.jwt.JwtProcess;
 import com.example.jariBean.entity.User;
+import com.example.jariBean.handler.ex.CustomApiException;
 import com.example.jariBean.repository.TokenRepository;
 import com.example.jariBean.repository.user.UserRepository;
 import com.example.jariBean.service.oauth.OAuthKakaoService;
+import com.example.jariBean.service.oauth.OAuthKakaoService.SocialUserInfo;
 import com.example.jariBean.service.oauth.OAuthService;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -19,24 +23,30 @@ class OAuthServiceTest {
     @Autowired UserRepository userRepository;
     @Autowired TokenRepository tokenRepository;
     @Autowired JwtProcess jwtProcess;
+    OAuthService oAuthService;
 
+    @BeforeEach
+    public void beforeEach() {
+        oAuthService = new OAuthKakaoService(userRepository, jwtProcess, tokenRepository);
+    }
 
     @Test
-    public void isExistUserTest() throws Exception {
+    public void saveOrUpdateTest() throws Exception {
+        // nickname is null
+        SocialUserInfo kakaoSocialUserInfo1 = SocialUserInfo.create("KAKAO", "kakao_id", "Guest", "kakak0_imageUrl");
+        oAuthService.saveOrUpdate(kakaoSocialUserInfo1);
 
-        OAuthService oAuthService = new OAuthKakaoService(userRepository, jwtProcess, tokenRepository);
+        User beforeFindUser = userRepository.findBySocialId("KAKAO_kakao_id")
+                .orElseThrow(() -> new CustomApiException("Could not find user information by social id"));
+        assertThat(beforeFindUser.getNickname()).isEqualTo("Guest");
 
-        // 회원가입을 하지 않은 유저
-        boolean isNotLoggedIn = oAuthService.isExistUser("no-social-id");
-        Assertions.assertThat(isNotLoggedIn).isEqualTo(false);
+        // nickname is not null
+        SocialUserInfo kakaoSocialUserInfo2 = SocialUserInfo.create("KAKAO", "kakao_id", "kakao_nickname", "kakak0_imageUrl");
+        oAuthService.saveOrUpdate(kakaoSocialUserInfo2);
 
-        // 회원가입된 유저
-        User user = User.builder().socialId("social-id").password("password").build();
-        userRepository.save(user);
-
-        boolean isLoggedIn = oAuthService.isExistUser(user.getSocialId());
-        Assertions.assertThat(isLoggedIn).isEqualTo(true);
-
+        User afterFindUser = userRepository.findBySocialId("KAKAO_kakao_id")
+                .orElseThrow(() -> new CustomApiException("Could not find user information by social id"));
+        assertThat(afterFindUser.getNickname()).isEqualTo("kakao_nickname");
     }
 
 }


### PR DESCRIPTION
# ✏️ Description
Google에 소셜 로그인 과정 중 사용자 정보를 조회 과정에서 Google 사용자의 `nickname` 필드의 값이 null인 경우가 있을 수 있다. 
`nickname` 필드 값을 null인 채로 방치한다면 서비스 제공 과정에서 오류가 발생할 수 있다.
```
{
    socialId=google_105677670165618934537,
    nickname=null,
    imageUrl=https://lh3.googleusercontent.com/a/default-user=s96-c
}
```

따라서 사용자 정보를 조회할 때 Google 사용자의 `nickname` 필드의 값이 null인 경우 default 값으로 `Guest` 값을 할당하기로 하였다.

# 🛠 Features
- [ ] 로그인 과정에서 `SocialUserInfo` 객체의 `nickname` 필드의 값이 null일 경우 `Guest` String 값 대입

> 혹시 유저가 닉네임을 변경해서 `null -> guest`였던 닉네임이 다른 닉네임으로 변경되어도 로그인이 잘 처리되는지 궁금합니다.

해당 이슈를 검증하기 위해 소셜미디어에서 사용자 정보를 조회한 후 변경된 값을 update해주는 로직의 테스트 코드를 작성하였고 닉네임의 변경이 발생하여도 데이터베이스에서 올바르게 update가 발생하는 것을 확인할 수 있습니다!

### Test Code
```java
    @Test
    public void saveOrUpdateTest() throws Exception {
        // nickname is null
        SocialUserInfo kakaoSocialUserInfo1 = SocialUserInfo.create("KAKAO", "kakao_id", "Guest", "kakak0_imageUrl");
        oAuthService.saveOrUpdate(kakaoSocialUserInfo1);

        User beforeFindUser = userRepository.findBySocialId("KAKAO_kakao_id")
                .orElseThrow(() -> new CustomApiException("Could not find user information by social id"));
        assertThat(beforeFindUser.getNickname()).isEqualTo("Guest");

        // nickname is not null
        SocialUserInfo kakaoSocialUserInfo2 = SocialUserInfo.create("KAKAO", "kakao_id", "kakao_nickname", "kakak0_imageUrl");
        oAuthService.saveOrUpdate(kakaoSocialUserInfo2);

        User afterFindUser = userRepository.findBySocialId("KAKAO_kakao_id")
                .orElseThrow(() -> new CustomApiException("Could not find user information by social id"));
        assertThat(afterFindUser.getNickname()).isEqualTo("kakao_nickname");
    }
```

### Result
<img width="344" alt="image" src="https://github.com/SWM-99-degree/jariBean/assets/85926257/85341947-ae45-4a19-858b-ad0e531712e6">
