### PR TITLE
refactor <김상현 #168> 매장 관리 앱 예약 내역 조회 관련 DTO 수정

### DIFF
--- a/src/test/java/com/example/jariBean/service/CafeSearchServiceTest.java
+++ b/src/test/java/com/example/jariBean/service/CafeSearchServiceTest.java
@@ -1,7 +1,5 @@
 package com.example.jariBean.service;
 
-import com.example.jariBean.dto.cafe.CafeReqDto;
-import com.example.jariBean.dto.cafe.CafeResDto;
 import com.example.jariBean.entity.Cafe;
 import com.example.jariBean.entity.Table;
 import com.example.jariBean.repository.cafe.CafeRepository;
@@ -11,19 +9,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.NoSuchElementException;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -62,37 +55,6 @@ public class CafeSearchServiceTest {
         objectId = new ObjectId(newCafe.getId());
         tableRepository.save(table);
 
-    }
-
-
-    @Test
-    public void findBySearchingTest(){
-        // given
-        Pageable pageable = Pageable.ofSize(1);
-        CafeReqDto.CafeSearchReqDto cafeSearchReqDto = new CafeReqDto.CafeSearchReqDto();
-        LocalDateTime dateTime1 = LocalDateTime.of(2023, 7, 1, 15, 0);
-        LocalDateTime dateTime2 = LocalDateTime.of(2023, 7, 1, 16, 0);
-        String text = "미추홀";
-        double latitude = 37.4467039276238;
-        double longitude = 126.4467039276238;
-        CafeReqDto.Location location = new CafeReqDto.Location();
-        location.setLatitude(latitude);
-        location.setLongitude(longitude);
-        cafeSearchReqDto.setSearchingWord(text);
-        cafeSearchReqDto.setLocation(location);
-        cafeSearchReqDto.setPeopleNumber(3);
-        cafeSearchReqDto.setReserveStartTime(dateTime1);
-        cafeSearchReqDto.setReserveEndTime(dateTime2);
-        cafeSearchReqDto.setTableOptionList(new ArrayList<>());
-
-        // when
-        Page<Cafe> cafes = searchService.findByText(cafeSearchReqDto,pageable);
-
-        // then
-        for (Cafe cafe : cafes) {
-            System.out.println(cafe.getId());
-            Assertions.assertEquals(cafe.getId(), cafe.getId());
-        }
     }
 
     // getCafeWithTodayReserved 과 동일한 로직이라서 추가적인 테스트 코드를 작성하지 않았습니다.


### PR DESCRIPTION
# ✏️ Description
현재 매장 관리 앱에서 예약 내역에 대한 UI는 타임 테이블 형식과 리스트 형식이 있다.
**타임 테이블 형식**의 예약 내역은 각 테이블을 기준으로 테이블 예약 내역을 DTO로 제공하고,
**리스트 형식**의 예약 내역은 다른 조건 없이 카페의 예약 내역을 DTO로 제공해야 한다.

<img width = 50% src="https://github.com/SWM-99-degree/jariBean/assets/85926257/6c2b2e77-3349-46e4-a680-a87262554619"/><img width = 50% src="https://github.com/SWM-99-degree/jariBean/assets/85926257/ff211f64-1e78-472f-bbfd-e5fc5a26b4b8"/>

따라서 각 UI 형식에 맞도록 Response 형식을 변환한다.

# 💡 Additional
추가적으로 `Reserved` Document의 구조도 변경하였다. 예약 내역에 존재하는 `userId` 와 `tableClassId`의 값을 `User` `TableClass`로 변경하였다. 근거는 다음과 같다.
- 무한대로 값이 늘어나는 리스트 형식이 아니다.
- `User`와 `TableClass`의 내용 전체를 필드로 사용하여도 부담이 될 정도의 큰 용량이 아니다.

# 🛠 Features
- [x] Document 수정
- [x] DTO 구조 변경
