### PR TITLE
[FEAT] 회원가입된 계정 탈퇴 로직 구현

### DIFF
--- a/src/main/java/com/example/jariBean/controller/OAuthController.java
+++ b/src/main/java/com/example/jariBean/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package com.example.jariBean.controller;
 
+import com.example.jariBean.config.auth.LoginUser;
 import com.example.jariBean.dto.ResponseDto;
 import com.example.jariBean.dto.oauth.LoginCode;
 import com.example.jariBean.dto.oauth.LoginResDto.LoginSuccessResDto;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -51,6 +53,19 @@ public class OAuthController {
         // save or update oauth information
         LoginSuccessResDto loginSuccessResDto = oAuthService.saveOrUpdate(socialUserInfo);
         return new ResponseEntity<>(new ResponseDto<>(1, "로그인 성공", loginSuccessResDto), OK);
+    }
+
+    @Operation(summary = "Canceling your account", description = "api for Canceling your account")
+    @ApiResponse(
+            responseCode = "200",
+            description = "계정 탈퇴 성공",
+            content = @Content(schema = @Schema(implementation = Void.class))
+    )
+    @DeleteMapping("/accounts")
+    public ResponseEntity withdraw(@AuthenticationPrincipal LoginUser loginUser) {
+        oAuthService = authServiceFactory.get("default");
+        oAuthService.deleteUser(loginUser.getUser().getId());
+        return new ResponseEntity<>(new ResponseDto<>(1, "계정 탈퇴 성공", null), OK);
     }
 
 }

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -72,4 +72,8 @@ public abstract class OAuthService {
         return userRepository.save(user);
     }
 
+    public void deleteUser(String id) {
+        userRepository.deleteById(id);
+    }
+
 }

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthServiceFactory.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthServiceFactory.java
@@ -20,7 +20,7 @@ public class OAuthServiceFactory {
             case "apple":
                 return oAuthAppleService;
             default:
-                return null;
+                return oauthKakaoService;
         }
     }
 }


### PR DESCRIPTION
# ✏️ Description
이전 계획은 회원 탈퇴 방법을 꽁꽁 숨겨서 회원 탈퇴를 사용자가 할 수 없도록 막으려고 하였지만, `Apple` social login의 경우 회원 탈퇴 기능을 구현하지 않으면 App Store에 해당 앱을 업로드할 수 없다.

***
[iOS APP 심사 중 아래와 같은 사유로 심사 리젝](https://velog.io/@givepro91/jjo2cyus)

Upcoming Requirement Reminder Note: This is a support message regarding upcoming requirements that may be relevant for your app.

Starting June 30, 2022, apps submitted to the App Store that support account creation must also include an option to initiate account deletion.

We noticed this app may support account creation. If it does not, you may disregard this message. If it already offers account deletion or you’re working to implement it, we appreciate your efforts to follow the App Store Review Guidelines. Apps submitted after June 30 that do not comply with the account deletion requirements in guideline 5.1.1(v) will not pass review.

Learn more about the account deletion requirements. If your app offers Sign in with Apple, use the Sign in with Apple REST API to revoke user tokens.
***
따라서 사용자가 원한다면 계정 탈퇴를 할 수 있도록 기능을 구현하였다.