### PR TITLE
[BUG] imageFile의 값이 없는 경우에도 S3 Bucket에 이미지가 업로드 되는 버그 수정

### DIFF
--- a/src/main/java/com/example/jariBean/service/S3Service.java
+++ b/src/main/java/com/example/jariBean/service/S3Service.java
@@ -39,6 +39,14 @@ public class S3Service {
     private String AWS_CDN_URL;
 
     public S3ImageResDto upload(MultipartFile imageFile) throws IOException {
+
+        // MultipartFile의 값이 null일 경우 예외처리
+        if(imageFile.isEmpty()) {
+            return S3ImageResDto.builder()
+                    .imageUrl(null)
+                    .build();
+        }
+
         // file exception
         checkFileValidation(imageFile);
 


### PR DESCRIPTION
# ✏️ Description
클라이언트에서 S3 Bucket에 이미지를 저장할 때 이미지의 값을 null로 전송할 경우 이미지가 저장되지 않아야 하지만,
현재 서버는 클라이언트로부터 받은 이미지 파일이 null일 경우 0Byte의 파일을 S3 Bucket에 저장하는 것을 확인하였다.

![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/37636001-dcc2-4973-a72a-2ba1ed0cb3fd)

따라서, 클라이언트로부터 받은 이미지 파일이 null일 경우 S3 Bucket에 접근하지 않고 예외 처리를 하도록 코드를 수정한다.

## 📌 S3Service
```java
public S3ImageResDto upload(MultipartFile imageFile) throws IOException {

    // MultipartFile의 값이 null일 경우 예외처리
    if(imageFile.isEmpty()) {
        return S3ImageResDto.builder()
                .imageUrl(null)
                .build();
    }

   ...

}
```
- `MultiPart.isEmpty()`의 경우 업로드된 파일의 내용이 비어있는지 혹은 파일이 업로드되었는지 확인할 때 사용
- 만약 MultiPart의 파일이 업로드 되어있지 않다면 S3 Bucket에 접근하지 않고 바로 null 값을 반환하도록 수정

## 🔥 Exception 예외처리를 하지 않은 이유!!!
`S3Service`에서 이미지를 업로드하는 로직은 현재 다양한 곳에서 사용되고 있다.
그 중 일부에서는 이미지를 파일의 업로드가 필수적이지 않은 로직도 존재한다.
따라서 Exception 처리를 하지 않고 null 값을 반환할 수 있도록 코드를 작성하였다.