### PR TITLE
bug <김상현 #191> WebClientResponseException, InternalServerError 예외처리

### DIFF
--- a/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.reactive.function.client.WebClientResponseException.InternalServerError;
 import org.springframework.web.server.MethodNotAllowedException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -105,5 +107,16 @@ public class CustomExceptionHandler {
         return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "filename의 URL encode에 문제가 발생하였습니다. "), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    @ExceptionHandler(WebClientResponseException.class)
+    public ResponseEntity webClientResponseException(WebClientResponseException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "외부 API 요청에서 문제가 발생하였습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(InternalServerError.class)
+    public ResponseEntity internalServerError(InternalServerError e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "서버 처리 과정에서 문제가 발생하였습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
 }


### PR DESCRIPTION
# 🔥 발생한 문제
현재 `https://api.jari-bean.com/login/google` 엔드포인트에 접근하면 다음과 같은 Response를 받는다.

<img width="447" alt="image" src="https://github.com/SWM-99-degree/jariBean/assets/85926257/746e88c0-67b3-4f38-9072-f4624636410f">

[MDN Web Docs](https://developer.mozilla.org/ko/docs/Web/HTTP/Status/500)에 따르면 500 Internal Server Error는 아래와 같이 정의할 수 있다.

```
하이퍼텍스트 전송 프로토콜 (HTTP) 500 Internal Server Error 서버 에러 응답 코드는
요청을 처리하는 과정에서 서버가 예상하지 못한 상황에 놓였다는 것을 나타냅니다.
```

즉, 현재 서버로 온 요청을 처리하는 과정에서 서버 내부에서 문제가 발생했음을 추축할 수 있다.

요청을 처리하는 과정에서 당연히 문제가 발생하지 않도록 하는 것이 최우선 과제이지만, 모든 문제를 예방할 순 없다.
또한, 클라이언트 측에서는 일관된 Resposne를 받아야지만 원활한 응답 처리를 수행할 수 있다.

따라서 차선책으로 `500 Internal Server Error`에 대한 예외처리를 수행하여 일정한 응답을 받을 수 있도록 개선해야 한다.

# 🛠 해결

## CustomExceptionHandler
```java
@ExceptionHandler(WebClientResponseException.class)
public ResponseEntity webClientResponseException(WebClientResponseException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "외부 API 요청에서 문제가 발생하였습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
}

@ExceptionHandler(InternalServerError.class)
public ResponseEntity internalServerError(InternalServerError e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "서버 처리 과정에서 문제가 발생하였습니다."), HttpStatus.INTERNAL_SERVER_ERROR);
}
```
- 외부 API 요청시 오류가 발생할 경우 `WebClientResponseException` 오류에 대한 예외처리
- 서버 내부에서 오류가 발생할 경우에 대한 `InternalServerError` 예외처리
