### PR TITLE
[FEAT] Social Login 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/example/jariBean/controller/OAuthController.java
+++ b/src/main/java/com/example/jariBean/controller/OAuthController.java
@@ -61,10 +61,12 @@ public class OAuthController {
             description = "계정 탈퇴 성공",
             content = @Content(schema = @Schema(implementation = Void.class))
     )
-    @DeleteMapping("/accounts")
-    public ResponseEntity withdraw(@AuthenticationPrincipal LoginUser loginUser) {
-        oAuthService = authServiceFactory.get("default");
-        oAuthService.deleteUser(loginUser.getUser().getId());
+    @DeleteMapping("/accounts/{registration}")
+    public ResponseEntity withdraw(@AuthenticationPrincipal LoginUser loginUser,
+                                   @RequestBody LoginCode loginCode,
+                                   @PathVariable String registration) {
+        oAuthService = authServiceFactory.get(registration);
+        oAuthService.deleteUser(loginUser.getUser().getId(), loginCode.getCode());
         return new ResponseEntity<>(new ResponseDto<>(1, "계정 탈퇴 성공", null), OK);
     }
 

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthAppleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthAppleService.java
@@ -79,7 +79,7 @@ public class OAuthAppleService extends OAuthService{
                 REGISTRATION,
                 sub,
                 "Guest",
-                null
+                "https://img.jari-bean.com/a0155280-ad92-4a29-9965-8f41b2aad98dVector.png"
         );
     }
 

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthAppleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthAppleService.java
@@ -83,6 +83,23 @@ public class OAuthAppleService extends OAuthService{
         );
     }
 
+    @Override
+    public void deleteUser(String id, String code) {
+        MultiValueMap<String, String> bodyValue = new LinkedMultiValueMap<>();
+        bodyValue.add("client_id", CLIENT_ID);
+        bodyValue.add("client_secret", createClientSecret());
+        bodyValue.add("token", getAccessToken(code));
+
+        WebClient client = WebClient.create();
+        client.post()
+                .uri("https://appleid.apple.com/auth/revoke")
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .bodyValue(bodyValue)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
     public String createClientSecret() {
         return Jwts.builder()
                 // header

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
@@ -69,4 +69,9 @@ public class OAuthGoogleService extends OAuthService{
                 userInfo.getPicture()
         );
     }
+
+    @Override
+    public void deleteUser(String id, String code) {
+        userRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 
 @Service
-public class OAuthKakaoService extends OAuthService{
+public class OAuthKakaoService extends OAuthService {
 
     @Value("${KAKAO_CLIENT_ID}")
     private String KAKAO_CLIENT_ID;
@@ -79,6 +79,11 @@ public class OAuthKakaoService extends OAuthService{
                 userInfo.getProperties().getNickname() != null ? userInfo.getProperties().getNickname() : "Guest",
                 userInfo.getProperties().getProfile_image()
         );
+    }
+
+    @Override
+    public void deleteUser(String id, String code) {
+        userRepository.deleteById(id);
     }
 
     @Getter

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -20,8 +20,8 @@ import static com.example.jariBean.entity.Role.UNREGISTERED;
 @RequiredArgsConstructor
 public abstract class OAuthService {
 
-    private final UserRepository userRepository;
-    private final TokenRepository tokenRepository;
+    protected final UserRepository userRepository;
+    protected final TokenRepository tokenRepository;
     private final JwtProcess jwtProcess;
 
     @Autowired
@@ -72,8 +72,6 @@ public abstract class OAuthService {
         return userRepository.save(user);
     }
 
-    public void deleteUser(String id) {
-        userRepository.deleteById(id);
-    }
+    public abstract void deleteUser(String id, String code);
 
 }


### PR DESCRIPTION
# ✏️ Description
소셜 로그인 기능을 통해 회원 가입한 유저가 서비스 회원 탈퇴를 위한 기능을 구현하였다.

`Kakao`와 `Google`의 경우 특별한 절차 없이 Database에 존재하는 `User` Document를 삭제한다.

`Apple`의 경우는 소셜 로그인한 유저 정보를 `POST https://appleid.apple.com/auth/revoke` 엔드 포인트를 통해 소셜 로그인한 상태를 해제해야 한다.

### 📌 `Revoke tokens`
![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/08b527d1-bf3a-4a52-b777-5bf76055d8c9)

회원 탈퇴 추상화 메소드를 만들고 해당 추상화 메소드를 상속받아서 각 상황에 맞게 구현한다.

### 💻 Kakao
```java
@Override
public void deleteUser(String id, String code) {
    userRepository.deleteById(id);
}
```

### 💻 Google
```java
@Override
public void deleteUser(String id, String code) {
    userRepository.deleteById(id);
}
```

### 💻 Apple
```java
@Override
public void deleteUser(String id, String code) {
    MultiValueMap<String, String> bodyValue = new LinkedMultiValueMap<>();
    bodyValue.add("client_id", CLIENT_ID);
    bodyValue.add("client_secret", createClientSecret());
    bodyValue.add("token", getAccessToken(code));

    WebClient client = WebClient.create();
    client.post()
            .uri("https://appleid.apple.com/auth/revoke")
            .contentType(APPLICATION_FORM_URLENCODED)
            .bodyValue(bodyValue)
            .retrieve()
            .bodyToMono(String.class)
            .block();
}
```