### PR TITLE
[REFACTOR] handling all of exception

### DIFF
--- a/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
@@ -131,6 +131,12 @@ public class CustomExceptionHandler {
         return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), "해당 되는 데이터가 없습니다. 다른 요청을 진행해주세요."), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity exception(Exception e) {
+        log.error(e.getMessage());
+        return new ResponseEntity(new ResponseDto<>(-1, e.getMessage(), "서버에서 오류가 발생했습니다. Issue를 남겨주세요!"), HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity methodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error(e.getMessage());


### PR DESCRIPTION
# 🔥 Problem
현재 서버에서 Exception이 발생할 경우 `@RestControllerAdvice`에서 처리하고 있다. 클라이언트에서 요청을 보내고 문제가 발생할 때 마다 서버의 로그를 확인하여 특정 Exception을 찾아내고 해당 Exception에 대한 Handler를 추가하는 방식으로 진행하고 있었다.

만약 handler에 등록하지 않은 Exception이 발생한다면 trace에서 운영환경에서의 구현이 노출된다는 문제점이 있다.

# 💡 Solution
```
All exception classes are subtypes of the java.lang.Exception class.
The Exception class is a subclass of the Throwable class.
Other than the Exception class there is another subclass called Error
which is derived from the Throwable class.
```

위 내용을 살펴보면 `Exception.class`는 모든 Exception의 Base class라는 것을 알 수 있다.

매번 예외가 발생할 때마다 해당 Exception에 대한 handler를 추가하는 것은 예외에 대한 자세한 정보를 전달하기 위해서 필요하다. 하지만, 서버에서 처리할 수 없는 Exception은 없어야 하므로 발생한 Exception이 Handler에 존재하지 않을 경우 default로 해당 Exception을 다뤄줄 Handler를 등록하였다.

```java
@ExceptionHandler(Exception.class)
public ResponseEntity exception(Exception e) {
    log.error(e.getMessage());
    return new ResponseEntity(new ResponseDto<>(-1, e.getMessage(), "서버에서 오류가 발생했습니다. Issue를 남겨주세요!"), HttpStatus.BAD_REQUEST);
}
```

조금만 생각해보면 `Exception.class`가 모든 Exception의 base class인 것을 알고 Handler처리를 할 수 있었는데 너무 수동적으로 생각했던 것 같다.