### PR TITLE
bug <김상현 #226> modify the http status code in the response

### DIFF
--- a/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/example/jariBean/handler/CustomExceptionHandler.java
@@ -31,7 +31,7 @@ public class CustomExceptionHandler {
     @ExceptionHandler(CustomNoContentException.class)
     public ResponseEntity<?> apiException(CustomNoContentException e) {
         log.error(e.getMessage());
-        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.OK);
     }
 
     @ExceptionHandler(CustomDBException.class)


### PR DESCRIPTION
# 🛠 Http Status code 204에 대한 개념과 사용방법

### Http Status code 204
```
HTTP 상태 코드 204 "No Content"는 서버에서 성공적인 요청을 처리했지만 응답으로 본문 (response body)을 반환하지 않음을 나타냅니다.
이것은 명시적으로 응답 본문이 비어있음을 의미하며, 클라이언트는 응답에서 어떠한 데이터도 받지 않는다는 것을 기대합니다.

따라서 HTTP 상태 코드 204를 사용하는 경우, 서버는 응답에 데이터를 포함해서는 안됩니다.
만약 서버가 어떤 데이터를 전달해야 한다면, 다른 상태 코드 (예: 200 OK)를 사용해야 합니다.
```

ChatGPT에 Http Status Code 204에 대한 질문의 응답이다. 내용을 보면 `클라이언트는 응답에서 어떠한 데이터도 받지 않는 것을 기대하고 HTTP 상태 코드 204를 사용하는 경우, 서버는 응답에 데이터를 포함해서는 안됩니다.` 라는 것을 알 수 있고, 우리가 `204`를 사용하는 경우는 다음과 같은 상황에서 적용해야 올바르게 Http Status code를 사용했다고 볼 수 있다.

### Http Status Code 204 사용 예시

1. 요청이 성공적으로 처리되었지만 응답으로 데이터를 반환할 필요가 없는 경우: 예를 들어, 클라이언트가 서버에 리소스의 업데이트를 요청하고, 서버는 리소스가 업데이트되었음을 확인하고 추가 데이터를 반환하지 않는 경우에 사용된다. 클라이언트는 단순히 요청의 성공을 확인하고 추가 정보를 받을 필요가 없을 때 유용하다.

2. DELETE 요청의 성공: 클라이언트가 DELETE 요청을 보내어 리소스를 삭제하고, 리소스가 성공적으로 삭제된 경우에 204 상태 코드를 사용한다. 삭제 후에 삭제된 리소스에 대한 추가 정보를 반환할 필요가 없는 경우에 사용한다.

3. PUT 또는 PATCH 요청의 성공: 클라이언트가 서버에 리소스를 업데이트하는 PUT 또는 PATCH 요청을 보내고, 업데이트가 성공적으로 완료되었을 때 204를 사용할 수 있다. 업데이트 작업 자체가 성공이며 추가 데이터가 필요하지 않을 때 유용하다.

4. HEAD 요청: HEAD 요청은 GET 요청과 유사하지만 응답에 본문이 없는 경우에 사용된다. 따라서 204 No Content 상태 코드가 사용될 수 있다.

HTTP 상태 코드 204는 요청의 성공을 나타내고, 추가 정보나 데이터가 필요하지 않을 때 사용된다. 클라이언트가 요청을 이해하고 처리했지만 응답 본문을 기대하지 않을 때 사용하는 것이 좋다.

# 🔥 프로젝트에 적용
현재 사용자의 카페 매장 예약 내역을 조회할 때 예약 내역이 존재하지 않는다면 Http Status Code에 204를 담아 전송하고 있다.

### getNearestReserved method
```java
// 정보가 없다면 null 값으로 반환하며, 예외처리로 204를 보냄
if (reserved == null) {
    throw new CustomNoContentException("예약이 존재하지 않습니다.");
}
```

### CustomNoContentExceptionHandler
```java
@ExceptionHandler(CustomNoContentException.class)
public ResponseEntity<?> apiException(CustomNoContentException e) {
    log.error(e.getMessage());
    return new ResponseEntity<>(new ResponseDto<>(-1, e.getMessage(), null), HttpStatus.NO_CONTENT);
}
```

`CustomNoContentExceptionHandler`에서는 분명 ResponseBody를 담아서 전송하도록 설정되어 있지만, 응답 결과는 다음과 같다.

### {{server}}/api/home/reserve 요청에 대한 응답
<img width="1526" alt="image" src="https://github.com/SWM-99-degree/jariBean/assets/85926257/b921db77-a4c1-4f9b-b1f9-c2465cd8758e">

Response Body의 모든 내용이 삭제되어 있다. 만약 현재 Response의 Http Status Code가 204(`NO_CONTENT`)일 경우 SpringMVC에서 자동으로 Body의 내용을 삭제하기 때문이다.

따라서 예약 내역이 존재하지 않아도 Response Body가 누락되지 않도록 하기 위해서는 Http Status Code를 200(`OK`)으로 수정하는 것이 올바른 사용법이지 않을까 생각한다.
