### PR TITLE
bug <김상현> when creating entity with dto, add status field

### DIFF
--- a/src/main/java/com/example/jariBean/dto/reserved/ReserveReqDto.java
+++ b/src/main/java/com/example/jariBean/dto/reserved/ReserveReqDto.java
@@ -15,6 +15,8 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
+import static com.example.jariBean.entity.Reserved.ReservedStatus.VALID;
+
 @Slf4j
 public class ReserveReqDto {
 
@@ -64,6 +66,7 @@ public class ReserveReqDto {
                     .table(table)
                     .startTime(super.startTime)
                     .endTime(super.endTime)
+                    .status(VALID)
                     .build();
         }
     }


### PR DESCRIPTION
# ✏️ Description
ReserveDto를 Reserve Document로 변환하는 메소드가 존재하였는데 해당 과정에서 `status` 필드에 대한 정보를 추가하는 것이 누락되어서 예약을 완료해도 조회가 불가능한 상황이 발생하였다. 해당 메소드에서 `status` 필드를 추가하도록 코드를 수정하였다.

### 💻 toEntity()
```java
public Reserved toEntity(User user, Table table, Cafe cafe) {
    return Reserved.builder()
            .user(user)
            .cafe(cafe)
            .table(table)
            .startTime(super.startTime)
            .endTime(super.endTime)
            .status(VALID) // 추가!
            .build();
}
```