### PR TITLE
[BUG] 예약 시작 시간과 끝 시간이 같아도 예약이 되는 오류 수정

### DIFF
--- a/src/main/java/com/example/jariBean/handler/constraintValidator/CustomValidator.java
+++ b/src/main/java/com/example/jariBean/handler/constraintValidator/CustomValidator.java
@@ -24,7 +24,7 @@ public class CustomValidator implements ConstraintValidator<CustomConstraint, Ti
             return false;
         }
 
-        if(startTime.isAfter(endTime)) {
+        if(!startTime.isBefore(endTime)) {
             return false;
         }
 


### PR DESCRIPTION
# ✏️ Description
예약 내역을 저장하기 위한 API를 호출할 때 예약 시작 시간(`startTime`)과 예약 끝 시간(`endTime`)이 같아도 예약 내역이 저장되어지는 오류를 발견하였다.

### 💻 [POST] {{server}}/api/reserve
![image](https://github.com/SWM-99-degree/jariBean/assets/85926257/f83a229d-d7ac-4c85-9067-a6d5673bd38c)

위 문제를 해결하기 위해서 유효성 검사를 해주는 `CustomValidator`의 `isValid()` 메소드를 일부 수정한다.

# 🔥 수정사항

### Before
```java
if(startTime.isAfter(endTime)) {
    return false;
}
```
기존의 코드는 `startTime` 이 `endTime` 보다 크다면 true를 반환하는 로직이다.
연산식으로 보면`startTime > endTime` 같다. 즉, 시작 시간과 끝 시간이 같은 상황에 대해서는 false 처리를 하지 않는다.

### After
```java
if(!startTime.isBefore(endTime)) {
    return false;
}
```
이후 수정한 코드는 `startTime` 보다 `endTime`이 보다 크거나 같다면 false를 반환하는 로직이다.
연산식으로 보면`startTime >= endTime` 같다. 즉, 예약 시작 시간이 끝 시간보다 크거나, 같을 경우 예외처리를 수행한다.