### PR TITLE
refactor <김상현 #239> when user join, update user image

### DIFF
--- a/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthGoogleService.java
@@ -66,7 +66,7 @@ public class OAuthGoogleService extends OAuthService{
                 REGISTRATION,
                 userInfo.getId(),
                 userInfo.getName() != null ? userInfo.getName() : "Guest",
-                userInfo.getPicture()
+                userInfo.getPicture() != null ? userInfo.getPicture() : "https://img.jari-bean.com/a0155280-ad92-4a29-9965-8f41b2aad98dVector.png"
         );
     }
 

--- a/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthKakaoService.java
@@ -77,7 +77,7 @@ public class OAuthKakaoService extends OAuthService {
                 REGISTRATION,
                 userInfo.getId(),
                 userInfo.getProperties().getNickname() != null ? userInfo.getProperties().getNickname() : "Guest",
-                userInfo.getProperties().getProfile_image()
+                userInfo.getProperties().getProfile_image() != null ? userInfo.getProperties().getProfile_image() : "https://img.jari-bean.com/a0155280-ad92-4a29-9965-8f41b2aad98dVector.png"
         );
     }
 


### PR DESCRIPTION
# ✏️ Description
현재 로그인은 카카오, 구글, 애플의 소셜 로그인만 가능한 상황이다. 만약 소셜 로그인을 통해 유저의 정보를 조회할 때 유저 이미지에 대한 정보가 존재하지 않는다면 해당 필드를 null 값을 할당하고 있었다.

소셜 정보에서 이미지가 존재하지 않을 경우 null로 처리하지 않고 기본 이미지를 할당하여 클라이언트에게 일관된 데이터를 반환하고자 한다.

# 💻 Code
만약 소셜 로그인을 통해 회원 정보를 조회할 때 이미지에 해당하는 값이 존재하지 않을 경우 기본 이미지를 제공하도록 코드를 수정하였다.
### getUserInfo()
```java
return SocialUserInfo.create(
        REGISTRATION,
        userInfo.getId(),
        userInfo.getName() != null ? userInfo.getName() : "Guest",
        userInfo.getPicture() != null ? userInfo.getPicture() : "https://img.jari-bean.com/a0155280-ad92-4a29-9965-8f41b2aad98dVector.png"
);
```

### getUserInfo()
```java
return SocialUserInfo.create(
        REGISTRATION,
        userInfo.getId(),
        userInfo.getProperties().getNickname() != null ? userInfo.getProperties().getNickname() : "Guest",
        userInfo.getProperties().getProfile_image() != null ? userInfo.getProperties().getProfile_image() : "https://img.jari-bean.com/a0155280-ad92-4a29-9965-8f41b2aad98dVector.png"
);
```