### PR TITLE
bug <김상현 #245> 회원가입 로직에서 이미지가 저장되지 않는 오류 수정

### DIFF
--- a/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
+++ b/src/main/java/com/example/jariBean/service/oauth/OAuthService.java
@@ -64,6 +64,7 @@ public abstract class OAuthService {
                 .orElse(User.builder()
                         .socialId(socialUserInfo.getSocialId())
                         .nickname(socialUserInfo.getNickname())
+                        .image(socialUserInfo.getImageUrl())
                         .password(passwordEncoder.encode(socialUserInfo.getNickname()))
                         .role(UNREGISTERED)
                         .build());


### PR DESCRIPTION
# ✏️ Description
과거 #202 문제에서 매 로그인시 이미지가 기본 이미지로 변경되는 것을 막기 위해 로그인 시 `image` 데이터를 갱신하는 로직을 제거하였다.
해당 부분에서 첫 회원가입시 이미지를 업데이트 하는 기능도 같이 제거되어 회원가입시 `image`에 해당하는 필드가 생성되지 않는 오류를 발생하였다.

# 🔥 Solution

### 💻 기존의 코드

```java
private User saveOrUpdateUser(SocialUserInfo socialUserInfo) {
    // save or create user
    User user = userRepository.findBySocialId(socialUserInfo.getSocialId())
            .orElse(User.builder()
                    .socialId(socialUserInfo.getSocialId())
                    .nickname(socialUserInfo.getNickname())
                    .password(passwordEncoder.encode(socialUserInfo.getNickname()))
                    .role(UNREGISTERED)
                    .build());
    return userRepository.save(user);
}
```

### 💻 수정된 코드
```java
private User saveOrUpdateUser(SocialUserInfo socialUserInfo) {
    // save or create user
    User user = userRepository.findBySocialId(socialUserInfo.getSocialId())
            .orElse(User.builder()
                    .socialId(socialUserInfo.getSocialId())
                    .nickname(socialUserInfo.getNickname())
                    .image(socialUserInfo.getImageUrl()) // 만약 socialId에 해당하는 유저가 존재하지 않는다면 image 값을 초기화한 Document 생성
                    .password(passwordEncoder.encode(socialUserInfo.getNickname()))
                    .role(UNREGISTERED)
                    .build());
    return userRepository.save(user);
}
```