### PR TITLE
bug <김상현 #253> modify null exception handler

### DIFF
--- a/src/main/java/com/example/jariBean/service/S3Service.java
+++ b/src/main/java/com/example/jariBean/service/S3Service.java
@@ -41,7 +41,7 @@ public class S3Service {
     public S3ImageResDto upload(MultipartFile imageFile) throws IOException {
 
         // MultipartFile의 값이 null일 경우 예외처리
-        if(imageFile.isEmpty()) {
+        if(imageFile == null || imageFile.isEmpty()) {
             return S3ImageResDto.builder()
                     .imageUrl(null)
                     .build();


### PR DESCRIPTION
# 🔥 문제
사용자 정보를 갱신할 때 `image`, `nickname`, `description`에 대한 내용을 수정할 수 있다.
사용자 측에서 만약 `nickname`에 대한 정보만을 수정할 때 나머지 `image`, `description`에 대한 정보는 Null로 전달된다.
만약 Null로 정보가 전달된다면 해당 정보는 수정하지 않도록 코드를 수정해야 한다.
### Exception Handler
```
2023-11-03 03:09:47.400 ERROR 1 --- [nio-8080-exec-2] c.e.j.handler.CustomExceptionHandler     :
 Cannot invoke "org.springframework.web.multipart.MultipartFile.isEmpty()" because "imageFile" is null
```
하지만 현재 `MultipartFile` 객체가 비어있는 상태인지 확인하는 로직인 `isEmpty()` 메서도는 존재하지만 객체 자체가 Null인 것을 확인하는 로직은 구현하지 않았다.

따라서 해당 로직을 추가하여 정상적으로 정보가 수정될 수 있도록 코드를 수정한다. 

# 🛠 수정사항
`MultipartFile` 자체가 Null일 경우도 고려하여 예외처리 로직을 수정하였다.
### 수정 전
```java
// MultipartFile의 값이 null일 경우 예외처리
if(imageFile.isEmpty()) {
    return S3ImageResDto.builder()
            .imageUrl(null)
            .build();
}
```

### 수정 후
```java
// MultipartFile의 값이 null일 경우 예외처리
if(imageFile == null || imageFile.isEmpty()) {
    return S3ImageResDto.builder()
            .imageUrl(null)
            .build();
}
```