### PR TITLE
[REFACTOR] 예약 내역 조회시 정렬 기능 적용

### DIFF
--- a/src/main/java/com/example/jariBean/repository/reserved/ReservedRepository.java
+++ b/src/main/java/com/example/jariBean/repository/reserved/ReservedRepository.java
@@ -16,6 +16,8 @@ public interface ReservedRepository extends MongoRepository<Reserved, String>, R
 
     Page<Reserved> findByUserIdOrderByStartTimeAsc(String userId, Pageable pageable);
 
+    Page<Reserved> findByUserIdOrderByStartTimeDesc(String userId, Pageable pageable);
+
     List<Reserved> findByTableIdIn(List<String> tableIdList);
 
 

--- a/src/main/java/com/example/jariBean/service/ReserveService.java
+++ b/src/main/java/com/example/jariBean/service/ReserveService.java
@@ -32,15 +32,9 @@ public class ReserveService {
     @Autowired private UserRepository userRepository;
 
     public Page<ReserveSummaryResDto> getMyReserved(String userId, Pageable pageable) {
-
-        Page<Reserved> reservedList = reservedRepository.findByUserIdOrderByStartTimeAsc(userId, pageable);
-        Page<ReserveSummaryResDto> reserveSummaryResDtoList = reservedList.map(reserved -> new ReserveSummaryResDto(reserved));
-
-        for (ReserveSummaryResDto reserveSummaryResDto : reserveSummaryResDtoList) {
-            System.out.println(reserveSummaryResDto.getReserveStartTime());
-        }
-
-        return reserveSummaryResDtoList;
+        return reservedRepository
+                .findByUserIdOrderByStartTimeDesc(userId, pageable)
+                .map(ReserveSummaryResDto::new);
     }
 
     // 예약 삭제하기


### PR DESCRIPTION
# ✏️ Description
`[GET] {{server}}/api/reserve` API를 통해 사용자의 예약 내역을 조회할 때 예약 내역이 오름차순으로 정렬되어 데이터를 반환하고 있다.
그래서 최근 예약 내역이 상단에 위치하는 것이 아니라 하단에 위치하여 만약 사용자가 최근 예약한 내역을 조회하려면 스크롤을 맨 끝까지 내려야 한다.

해당 문제를 해결하기 위해서 오름차순 정렬이 아닌 내림차순 정렬로 예약을 정렬하여 응답할 수 있도록 코드를 수정한다.

# 💻 수정

Data JPA를 이용한 쿼리 메소드 `findByUserIdOrderByStartTimeAsc()` 를 `findByUserIdOrderByStartTimeDesc()`로 변경하여 사용하였다.

### 수정 전
```java
public Page<ReserveSummaryResDto> getMyReserved(String userId, Pageable pageable) {

    Page<Reserved> reservedList = reservedRepository.findByUserIdOrderByStartTimeAsc(userId, pageable);
    Page<ReserveSummaryResDto> reserveSummaryResDtoList = reservedList.map(reserved -> new ReserveSummaryResDto(reserved));

    for (ReserveSummaryResDto reserveSummaryResDto : reserveSummaryResDtoList) {
        System.out.println(reserveSummaryResDto.getReserveStartTime());
    }

    return reserveSummaryResDtoList;
}
```

### 수정 후
```java
public Page<ReserveSummaryResDto> getMyReserved(String userId, Pageable pageable) {
    return reservedRepository
            .findByUserIdOrderByStartTimeDesc(userId, pageable)
            .map(ReserveSummaryResDto::new);
}
```